### PR TITLE
feat: PDF export with print CSS and accessibility modal

### DIFF
--- a/src/app/(app)/vpats/__tests__/view-page.test.tsx
+++ b/src/app/(app)/vpats/__tests__/view-page.test.tsx
@@ -8,6 +8,9 @@ vi.mock('next/navigation', () => ({
   useRouter: vi.fn(() => ({ push: vi.fn(), refresh: vi.fn() })),
   useParams: () => ({ id: 'vpat-1' }),
 }));
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => key,
+}));
 
 const mockVpat = {
   id: 'vpat-1',

--- a/src/components/vpats/__tests__/pdf-export-modal.test.tsx
+++ b/src/components/vpats/__tests__/pdf-export-modal.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+
+// Mock next-intl — returns the translation key as the display string
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+// Capture window.open calls
+const mockWindowOpen = vi.fn();
+const mockPrint = vi.fn();
+beforeEach(() => {
+  vi.clearAllMocks();
+  global.fetch = vi.fn();
+  global.window.open = mockWindowOpen;
+});
+
+import { PdfExportModal } from '../pdf-export-modal';
+
+const baseProps = {
+  open: true,
+  onOpenChange: vi.fn(),
+  vpatId: 'vpat-1',
+};
+
+describe('PdfExportModal', () => {
+  it('renders the dialog title when open', () => {
+    render(<PdfExportModal {...baseProps} />);
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByText('title')).toBeInTheDocument();
+  });
+
+  it('renders the browser PDF warning paragraph', () => {
+    render(<PdfExportModal {...baseProps} />);
+    expect(screen.getByText('browser_warning')).toBeInTheDocument();
+  });
+
+  it('renders the accessible PDF paragraph', () => {
+    render(<PdfExportModal {...baseProps} />);
+    expect(screen.getByText('accessible_alternative')).toBeInTheDocument();
+  });
+
+  it('renders "Continue to Print" and "Download DOCX instead" buttons', () => {
+    render(<PdfExportModal {...baseProps} />);
+    expect(screen.getByRole('button', { name: 'continue_to_print' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'download_docx' })).toBeInTheDocument();
+  });
+
+  it('does not render when open is false', () => {
+    render(<PdfExportModal {...baseProps} open={false} />);
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('"Continue to Print" fetches HTML export and opens print dialog', async () => {
+    const mockNewWindow = {
+      document: { write: vi.fn(), close: vi.fn() },
+      print: mockPrint,
+      focus: vi.fn(),
+      addEventListener: vi.fn(),
+    };
+    mockWindowOpen.mockReturnValue(mockNewWindow);
+    const htmlBlob = new Blob(['<html></html>'], { type: 'text/html' });
+    vi.mocked(global.fetch).mockResolvedValueOnce({
+      ok: true,
+      blob: () => Promise.resolve(htmlBlob),
+    } as unknown as Response);
+
+    render(<PdfExportModal {...baseProps} />);
+    await userEvent.click(screen.getByRole('button', { name: 'continue_to_print' }));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith('/api/vpats/vpat-1/export?format=html');
+    });
+    await waitFor(() => {
+      expect(mockWindowOpen).toHaveBeenCalled();
+    });
+  });
+
+  it('"Download DOCX instead" navigates to DOCX export URL and closes modal', async () => {
+    const onOpenChange = vi.fn();
+    delete (window as unknown as { location: unknown }).location;
+    (window as unknown as { location: { href: string } }).location = { href: '' };
+
+    render(<PdfExportModal {...baseProps} onOpenChange={onOpenChange} />);
+    await userEvent.click(screen.getByRole('button', { name: 'download_docx' }));
+
+    expect((window as unknown as { location: { href: string } }).location.href).toBe(
+      '/api/vpats/vpat-1/export?format=docx'
+    );
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+});

--- a/src/components/vpats/__tests__/vpat-settings-menu.test.tsx
+++ b/src/components/vpats/__tests__/vpat-settings-menu.test.tsx
@@ -13,6 +13,9 @@ vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: mockPush, refresh: mockRefresh }),
 }));
 vi.mock('sonner', () => ({ toast: { success: mockToastSuccess, error: mockToastError } }));
+vi.mock('../pdf-export-modal', () => ({
+  PdfExportModal: ({ open }: { open: boolean }) => (open ? <div data-testid="pdf-modal" /> : null),
+}));
 global.fetch = vi.fn();
 
 import { VpatSettingsMenu } from '../vpat-settings-menu';
@@ -346,5 +349,22 @@ describe('VpatSettingsMenu Publish count line', () => {
     await user.click(screen.getByRole('menuitem', { name: /^publish$/i }));
     await waitFor(() => expect(screen.getByRole('alertdialog')).toBeInTheDocument());
     expect(screen.getByText(/all 4 criteria have been evaluated/i)).toBeInTheDocument();
+  });
+});
+
+describe('PDF export', () => {
+  it('shows a "Print to PDF…" menu item', async () => {
+    const user = userEvent.setup();
+    render(<VpatSettingsMenu {...baseProps} />);
+    await user.click(screen.getByRole('button', { name: /vpat settings/i }));
+    expect(screen.getByRole('menuitem', { name: /print to pdf/i })).toBeInTheDocument();
+  });
+
+  it('clicking "Print to PDF…" opens the PDF modal', async () => {
+    const user = userEvent.setup();
+    render(<VpatSettingsMenu {...baseProps} />);
+    await user.click(screen.getByRole('button', { name: /vpat settings/i }));
+    await user.click(screen.getByRole('menuitem', { name: /print to pdf/i }));
+    expect(screen.getByTestId('pdf-modal')).toBeInTheDocument();
   });
 });

--- a/src/components/vpats/pdf-export-modal.tsx
+++ b/src/components/vpats/pdf-export-modal.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+
+interface PdfExportModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  vpatId: string;
+}
+
+/**
+ * PdfExportModal — Explains browser-PDF accessibility limitations before
+ * triggering window.print() via the existing HTML export.
+ *
+ * "Continue to Print": fetches /api/vpats/[vpatId]/export?format=html,
+ * opens the blob in a new tab, then calls window.print() on that tab.
+ *
+ * "Download DOCX instead": navigates to the DOCX export URL and closes the
+ * modal — recommended for accessible PDF output via Word/LibreOffice.
+ */
+export function PdfExportModal({ open, onOpenChange, vpatId }: PdfExportModalProps) {
+  const t = useTranslations('vpats.pdf_modal');
+
+  async function handlePrint() {
+    const res = await fetch(`/api/vpats/${vpatId}/export?format=html`);
+    if (!res.ok) return;
+    const blob = await res.blob();
+    const url = URL.createObjectURL(blob);
+    const newWindow = window.open(url);
+    if (newWindow) {
+      newWindow.focus();
+      newWindow.addEventListener('load', () => {
+        newWindow.print();
+      });
+    }
+  }
+
+  function handleDocx() {
+    window.location.href = `/api/vpats/${vpatId}/export?format=docx`;
+    onOpenChange(false);
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{t('title')}</DialogTitle>
+          <DialogDescription asChild>
+            <div className="space-y-3 text-sm text-muted-foreground">
+              <p>{t('browser_warning')}</p>
+              <p>{t('accessible_alternative')}</p>
+            </div>
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter className="gap-2">
+          <Button variant="outline" onClick={handleDocx}>
+            {t('download_docx')}
+          </Button>
+          <Button onClick={handlePrint}>{t('continue_to_print')}</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/vpats/vpat-settings-menu.tsx
+++ b/src/components/vpats/vpat-settings-menu.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { toast } from 'sonner';
 import { Settings, Send, Download, Trash2, Pencil, CheckCircle } from 'lucide-react';
+import { PdfExportModal } from './pdf-export-modal';
 import { Button, buttonVariants } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import {
@@ -104,6 +105,7 @@ export function VpatSettingsMenu({
   const [reviewerName, setReviewerName] = useState('');
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [editOpen, setEditOpen] = useState(false);
+  const [pdfOpen, setPdfOpen] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
   const reviewerInputRef = useRef<HTMLInputElement>(null);
 
@@ -212,6 +214,10 @@ export function VpatSettingsMenu({
               <Download className="mr-2 h-4 w-4" />
               OpenACR (YAML)
             </a>
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={() => setPdfOpen(true)}>
+            <Download className="mr-2 h-4 w-4" />
+            Print to PDF…
           </DropdownMenuItem>
           <DropdownMenuSeparator />
           <DropdownMenuItem onSelect={() => setDeleteOpen(true)}>
@@ -417,6 +423,8 @@ export function VpatSettingsMenu({
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
+
+      <PdfExportModal open={pdfOpen} onOpenChange={setPdfOpen} vpatId={vpatId} />
     </>
   );
 }

--- a/src/lib/export/__tests__/vpat-template.test.ts
+++ b/src/lib/export/__tests__/vpat-template.test.ts
@@ -267,3 +267,20 @@ describe('generateVpatHtml — cover sheet', () => {
     expect(result).toContain('&lt;script&gt;');
   });
 });
+
+describe('print CSS', () => {
+  it('includes @media print block', () => {
+    const html = generateVpatHtml(mockVpat, mockProject, []);
+    expect(html).toContain('@media print');
+  });
+
+  it('hides .no-print elements in print CSS', () => {
+    const html = generateVpatHtml(mockVpat, mockProject, []);
+    expect(html).toContain('.no-print { display: none !important; }');
+  });
+
+  it('avoids page breaks inside tables in print CSS', () => {
+    const html = generateVpatHtml(mockVpat, mockProject, []);
+    expect(html).toContain('page-break-inside: avoid');
+  });
+});

--- a/src/lib/export/vpat-template.ts
+++ b/src/lib/export/vpat-template.ts
@@ -334,6 +334,7 @@ export function generateVpatHtml(
 
     /* Print styles */
     @media print {
+      .no-print { display: none !important; }
       body {
         font-size: 10pt;
       }

--- a/src/messages/de.json
+++ b/src/messages/de.json
@@ -49,6 +49,13 @@
       "generate": "Generate PDF",
       "download": "Download PDF",
       "generating": "Generating…"
+    },
+    "pdf_modal": {
+      "title": "Als PDF drucken",
+      "browser_warning": "Ihr Browser erstellt eine PDF-Datei. Hinweis: Vom Browser generierte PDFs sind nicht getaggt und möglicherweise nicht für Screenreader-Nutzer zugänglich.",
+      "accessible_alternative": "Für ein zugängliches PDF für formelle Zwecke laden Sie das DOCX herunter und verwenden Sie die Option 'Als PDF exportieren' in Word oder LibreOffice mit aktivierten Barrierefreiheitsoptionen.",
+      "continue_to_print": "Weiter zum Drucken",
+      "download_docx": "Stattdessen DOCX herunterladen"
     }
   },
   "settings": {

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -49,6 +49,13 @@
       "generate": "Generate PDF",
       "download": "Download PDF",
       "generating": "Generating…"
+    },
+    "pdf_modal": {
+      "title": "Print to PDF",
+      "browser_warning": "Your browser will generate a PDF file. Note: browser-generated PDFs are not tagged and may not be accessible to screen reader users.",
+      "accessible_alternative": "For an accessible PDF suitable for formal disclosure, download the DOCX and use Word or LibreOffice's 'Export as PDF' with accessibility options enabled.",
+      "continue_to_print": "Continue to Print",
+      "download_docx": "Download DOCX instead"
     }
   },
   "settings": {

--- a/src/messages/es.json
+++ b/src/messages/es.json
@@ -49,6 +49,13 @@
       "generate": "Generate PDF",
       "download": "Download PDF",
       "generating": "Generating…"
+    },
+    "pdf_modal": {
+      "title": "Imprimir a PDF",
+      "browser_warning": "Su navegador generará un archivo PDF. Nota: los PDF generados por el navegador no están etiquetados y pueden no ser accesibles para los lectores de pantalla.",
+      "accessible_alternative": "Para un PDF accesible adecuado para divulgación formal, descargue el DOCX y use la opción 'Exportar como PDF' de Word o LibreOffice con las opciones de accesibilidad habilitadas.",
+      "continue_to_print": "Continuar a imprimir",
+      "download_docx": "Descargar DOCX en su lugar"
     }
   },
   "settings": {

--- a/src/messages/fr.json
+++ b/src/messages/fr.json
@@ -49,6 +49,13 @@
       "generate": "Generate PDF",
       "download": "Download PDF",
       "generating": "Generating…"
+    },
+    "pdf_modal": {
+      "title": "Imprimer en PDF",
+      "browser_warning": "Votre navigateur générera un fichier PDF. Remarque : les PDF générés par le navigateur ne sont pas balisés et peuvent ne pas être accessibles aux lecteurs d'écran.",
+      "accessible_alternative": "Pour un PDF accessible adapté à une divulgation formelle, téléchargez le DOCX et utilisez l'option « Exporter en PDF » de Word ou LibreOffice avec les options d'accessibilité activées.",
+      "continue_to_print": "Continuer vers l'impression",
+      "download_docx": "Télécharger DOCX à la place"
     }
   },
   "settings": {


### PR DESCRIPTION
## Summary
- Adds \`@media print\` CSS with \`.no-print\` rule to the VPAT HTML export template for clean browser printing
- New \`PdfExportModal\` component warns users about browser-PDF accessibility limitations before printing, with an option to download DOCX instead
- Wires \`PdfExportModal\` into \`VpatSettingsMenu\` as a "Print to PDF…" menu item
- Adds \`vpats.pdf_modal\` translation keys for en/fr/es/de

## Test Plan
- [x] Open a VPAT detail page and click the settings menu — "Print to PDF…" item is present
- [x] Clicking "Print to PDF…" opens the accessibility warning modal
- [x] "Continue to Print" fetches HTML export and opens browser print dialog
- [ ] "Download DOCX instead" triggers DOCX download and closes modal
- [x] All 1806 unit tests pass