### PR TITLE
feat: per-task AI model selection and AI Review Pass

### DIFF
--- a/e2e/vpat-edit.spec.ts
+++ b/e2e/vpat-edit.spec.ts
@@ -1,0 +1,129 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * E2E tests for VPAT edit page — remarks persistence and AI generation.
+ *
+ * Each test creates its own project + VPAT via the API and cleans up after itself.
+ */
+
+let projectId: string;
+let vpatId: string;
+
+test.beforeEach(async ({ request }) => {
+  // Create project
+  const projectRes = await request.post('/api/projects', {
+    data: { name: 'E2E VPAT Edit Project' },
+  });
+  expect(projectRes.ok()).toBeTruthy();
+  projectId = (await projectRes.json()).data.id;
+
+  // Create WCAG VPAT
+  const vpatRes = await request.post('/api/vpats', {
+    data: {
+      title: 'E2E VPAT Edit',
+      project_id: projectId,
+      standard_edition: 'WCAG',
+      wcag_version: '2.1',
+      wcag_level: 'AA',
+      product_scope: ['web'],
+    },
+  });
+  expect(vpatRes.ok()).toBeTruthy();
+  vpatId = (await vpatRes.json()).data.id;
+});
+
+test.afterEach(async ({ request }) => {
+  if (projectId) await request.delete(`/api/projects/${projectId}`);
+});
+
+test('typing remarks and saving persists to view and edit pages', async ({ page }) => {
+  await page.goto(`/vpats/${vpatId}/edit`);
+  await expect(page.getByRole('heading', { name: 'E2E VPAT Edit' })).toBeVisible();
+
+  // Click Level A tab (exact: true avoids matching Level AA / Level AAA)
+  await page.getByRole('tab', { name: 'Level A', exact: true }).click();
+
+  // Find the remarks textarea for criterion 1.1.1 (Non-text Content)
+  const textarea = page.getByRole('textbox', { name: /Remarks for 1\.1\.1/i });
+  await expect(textarea).toBeVisible();
+
+  // Type into it and wait for the 500ms debounce to flush
+  await textarea.fill('Test');
+  await page.waitForTimeout(600);
+
+  // Click "Save VPAT" and wait for the PATCH request to complete
+  const patchDone = page.waitForResponse(
+    (resp) => resp.url().includes('/rows/') && resp.request().method() === 'PATCH'
+  );
+  await page.getByRole('button', { name: /Save VPAT/i }).click();
+  await patchDone;
+
+  // Should navigate to the read-only view page
+  await expect(page).toHaveURL(new RegExp(`/vpats/${vpatId}$`), { timeout: 10000 });
+
+  // Open Level A tab on the view page — it defaults to cover-sheet
+  await page.getByRole('tab', { name: 'Level A', exact: true }).click();
+
+  // Remarks should appear on the read-only view
+  await expect(page.getByText('Test')).toBeVisible();
+
+  // Go back to edit and verify the remarks are still there
+  await page.goto(`/vpats/${vpatId}/edit`);
+  await page.getByRole('tab', { name: 'Level A', exact: true }).click();
+
+  const editTextarea = page.getByRole('textbox', { name: /Remarks for 1\.1\.1/i });
+  await expect(editTextarea).toHaveValue('Test');
+});
+
+test('AI generation updates the textarea with generated remarks', async ({ page, request }) => {
+  // Fetch the VPAT data to get the actual row IDs
+  const vpatRes = await request.get(`/api/vpats/${vpatId}`);
+  const vpatData = (await vpatRes.json()).data;
+  const row111 = vpatData.criterion_rows.find(
+    (r: { criterion_code: string }) => r.criterion_code === '1.1.1'
+  );
+  expect(row111).toBeTruthy();
+
+  const generatedRemarks = 'AI generated: Images must have descriptive alt text.';
+
+  // Intercept the generate API and return a mock response
+  await page.route(`/api/vpats/${vpatId}/rows/${row111.id}/generate`, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        success: true,
+        data: {
+          ...row111,
+          remarks: generatedRemarks,
+          ai_confidence: 'high',
+          ai_reasoning: 'Based on the issues found.',
+          ai_suggested_conformance: 'does_not_support',
+          ai_referenced_issues: [],
+          last_generated_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+        },
+      }),
+    });
+  });
+
+  await page.goto(`/vpats/${vpatId}/edit`);
+  await expect(page.getByRole('heading', { name: 'E2E VPAT Edit' })).toBeVisible();
+
+  // Click Level A tab
+  await page.getByRole('tab', { name: 'Level A', exact: true }).click();
+
+  // Find and click the Generate button for 1.1.1
+  const generateBtn = page.getByRole('button', { name: /Generate for 1\.1\.1/i });
+  await expect(generateBtn).toBeVisible();
+  await generateBtn.click();
+
+  // Wait for generation to complete (button returns from "Generating…" to "Generate")
+  await expect(page.getByRole('button', { name: /Generate for 1\.1\.1/i })).toBeVisible({
+    timeout: 10000,
+  });
+
+  // Textarea should now show the AI-generated remarks
+  const textarea = page.getByRole('textbox', { name: /Remarks for 1\.1\.1/i });
+  await expect(textarea).toHaveValue(generatedRemarks);
+});

--- a/e2e/vpat-edit.spec.ts
+++ b/e2e/vpat-edit.spec.ts
@@ -7,20 +7,124 @@ import { test, expect } from '@playwright/test';
  */
 
 let projectId: string;
-let vpatId: string;
 
 test.beforeEach(async ({ request }) => {
-  // Create project
   const projectRes = await request.post('/api/projects', {
     data: { name: 'E2E VPAT Edit Project' },
   });
   expect(projectRes.ok()).toBeTruthy();
   projectId = (await projectRes.json()).data.id;
+});
 
-  // Create WCAG VPAT
+test.afterEach(async ({ request }) => {
+  if (projectId) await request.delete(`/api/projects/${projectId}`);
+});
+
+// ─── Single-component row ────────────────────────────────────────────────────
+
+test('single-component: typing remarks and saving persists to view and edit pages', async ({
+  page,
+  request,
+}) => {
   const vpatRes = await request.post('/api/vpats', {
     data: {
-      title: 'E2E VPAT Edit',
+      title: 'E2E VPAT Single',
+      project_id: projectId,
+      standard_edition: 'WCAG',
+      wcag_version: '2.1',
+      wcag_level: 'AA',
+      product_scope: ['web'], // single component → standard row layout
+    },
+  });
+  expect(vpatRes.ok()).toBeTruthy();
+  const vpatId = (await vpatRes.json()).data.id;
+
+  await page.goto(`/vpats/${vpatId}/edit`);
+  await expect(page.getByRole('heading', { name: 'E2E VPAT Single' })).toBeVisible();
+
+  await page.getByRole('tab', { name: 'Level A', exact: true }).click();
+
+  const textarea = page.getByRole('textbox', { name: /Remarks for 1\.1\.1/i });
+  await expect(textarea).toBeVisible();
+
+  await textarea.fill('Test single');
+  await page.waitForTimeout(600);
+
+  const patchDone = page.waitForResponse(
+    (resp) => resp.url().includes('/rows/') && resp.request().method() === 'PATCH'
+  );
+  await page.getByRole('button', { name: /Save VPAT/i }).click();
+  await patchDone;
+
+  await expect(page).toHaveURL(new RegExp(`/vpats/${vpatId}$`), { timeout: 10000 });
+  await page.getByRole('tab', { name: 'Level A', exact: true }).click();
+  await expect(page.getByText('Test single')).toBeVisible();
+
+  // Back to edit — value should still be there
+  await page.goto(`/vpats/${vpatId}/edit`);
+  await page.getByRole('tab', { name: 'Level A', exact: true }).click();
+  await expect(page.getByRole('textbox', { name: /Remarks for 1\.1\.1/i })).toHaveValue(
+    'Test single'
+  );
+});
+
+// ─── Multi-component row ─────────────────────────────────────────────────────
+
+test('multi-component: typing remarks saves via component API and persists', async ({
+  page,
+  request,
+}) => {
+  // web + software-desktop + documents produces 3 components (web / software / electronic-docs)
+  const vpatRes = await request.post('/api/vpats', {
+    data: {
+      title: 'E2E VPAT Multi',
+      project_id: projectId,
+      standard_edition: 'WCAG',
+      wcag_version: '2.1',
+      wcag_level: 'AA',
+      product_scope: ['web', 'software-desktop', 'documents'],
+    },
+  });
+  expect(vpatRes.ok()).toBeTruthy();
+  const vpatId = (await vpatRes.json()).data.id;
+
+  await page.goto(`/vpats/${vpatId}/edit`);
+  await expect(page.getByRole('heading', { name: 'E2E VPAT Multi' })).toBeVisible();
+
+  await page.getByRole('tab', { name: 'Level A', exact: true }).click();
+
+  // The "web" component's remarks textarea for 1.1.1
+  const textarea = page.getByRole('textbox', {
+    name: /Remarks for 1\.1\.1 — web/i,
+  });
+  await expect(textarea).toBeVisible();
+
+  // Type and wait for the component PUT to fire
+  const putDone = page.waitForResponse(
+    (resp) => resp.url().includes('/components/') && resp.request().method() === 'PUT'
+  );
+  await textarea.fill('Test multi-component');
+  await putDone;
+
+  // Navigate to the read-only view and verify the remark shows
+  await page.goto(`/vpats/${vpatId}`);
+  await page.getByRole('tab', { name: 'Level A', exact: true }).click();
+  await expect(page.getByText('Test multi-component')).toBeVisible();
+
+  // Back to edit — textarea should still show the value
+  await page.goto(`/vpats/${vpatId}/edit`);
+  await page.getByRole('tab', { name: 'Level A', exact: true }).click();
+  await expect(page.getByRole('textbox', { name: /Remarks for 1\.1\.1 — web/i })).toHaveValue(
+    'Test multi-component'
+  );
+});
+
+// ─── AI generation ───────────────────────────────────────────────────────────
+
+test('AI generation updates the textarea with generated remarks', async ({ page, request }) => {
+  const vpatRes = await request.post('/api/vpats', {
+    data: {
+      title: 'E2E VPAT AI',
       project_id: projectId,
       standard_edition: 'WCAG',
       wcag_version: '2.1',
@@ -29,56 +133,9 @@ test.beforeEach(async ({ request }) => {
     },
   });
   expect(vpatRes.ok()).toBeTruthy();
-  vpatId = (await vpatRes.json()).data.id;
-});
+  const vpatId = (await vpatRes.json()).data.id;
 
-test.afterEach(async ({ request }) => {
-  if (projectId) await request.delete(`/api/projects/${projectId}`);
-});
-
-test('typing remarks and saving persists to view and edit pages', async ({ page }) => {
-  await page.goto(`/vpats/${vpatId}/edit`);
-  await expect(page.getByRole('heading', { name: 'E2E VPAT Edit' })).toBeVisible();
-
-  // Click Level A tab (exact: true avoids matching Level AA / Level AAA)
-  await page.getByRole('tab', { name: 'Level A', exact: true }).click();
-
-  // Find the remarks textarea for criterion 1.1.1 (Non-text Content)
-  const textarea = page.getByRole('textbox', { name: /Remarks for 1\.1\.1/i });
-  await expect(textarea).toBeVisible();
-
-  // Type into it and wait for the 500ms debounce to flush
-  await textarea.fill('Test');
-  await page.waitForTimeout(600);
-
-  // Click "Save VPAT" and wait for the PATCH request to complete
-  const patchDone = page.waitForResponse(
-    (resp) => resp.url().includes('/rows/') && resp.request().method() === 'PATCH'
-  );
-  await page.getByRole('button', { name: /Save VPAT/i }).click();
-  await patchDone;
-
-  // Should navigate to the read-only view page
-  await expect(page).toHaveURL(new RegExp(`/vpats/${vpatId}$`), { timeout: 10000 });
-
-  // Open Level A tab on the view page — it defaults to cover-sheet
-  await page.getByRole('tab', { name: 'Level A', exact: true }).click();
-
-  // Remarks should appear on the read-only view
-  await expect(page.getByText('Test')).toBeVisible();
-
-  // Go back to edit and verify the remarks are still there
-  await page.goto(`/vpats/${vpatId}/edit`);
-  await page.getByRole('tab', { name: 'Level A', exact: true }).click();
-
-  const editTextarea = page.getByRole('textbox', { name: /Remarks for 1\.1\.1/i });
-  await expect(editTextarea).toHaveValue('Test');
-});
-
-test('AI generation updates the textarea with generated remarks', async ({ page, request }) => {
-  // Fetch the VPAT data to get the actual row IDs
-  const vpatRes = await request.get(`/api/vpats/${vpatId}`);
-  const vpatData = (await vpatRes.json()).data;
+  const vpatData = (await (await request.get(`/api/vpats/${vpatId}`)).json()).data;
   const row111 = vpatData.criterion_rows.find(
     (r: { criterion_code: string }) => r.criterion_code === '1.1.1'
   );
@@ -86,7 +143,6 @@ test('AI generation updates the textarea with generated remarks', async ({ page,
 
   const generatedRemarks = 'AI generated: Images must have descriptive alt text.';
 
-  // Intercept the generate API and return a mock response
   await page.route(`/api/vpats/${vpatId}/rows/${row111.id}/generate`, async (route) => {
     await route.fulfill({
       status: 200,
@@ -97,7 +153,7 @@ test('AI generation updates the textarea with generated remarks', async ({ page,
           ...row111,
           remarks: generatedRemarks,
           ai_confidence: 'high',
-          ai_reasoning: 'Based on the issues found.',
+          ai_reasoning: 'Based on issues found.',
           ai_suggested_conformance: 'does_not_support',
           ai_referenced_issues: [],
           last_generated_at: new Date().toISOString(),
@@ -108,22 +164,15 @@ test('AI generation updates the textarea with generated remarks', async ({ page,
   });
 
   await page.goto(`/vpats/${vpatId}/edit`);
-  await expect(page.getByRole('heading', { name: 'E2E VPAT Edit' })).toBeVisible();
-
-  // Click Level A tab
+  await expect(page.getByRole('heading', { name: 'E2E VPAT AI' })).toBeVisible();
   await page.getByRole('tab', { name: 'Level A', exact: true }).click();
 
-  // Find and click the Generate button for 1.1.1
-  const generateBtn = page.getByRole('button', { name: /Generate for 1\.1\.1/i });
-  await expect(generateBtn).toBeVisible();
-  await generateBtn.click();
-
-  // Wait for generation to complete (button returns from "Generating…" to "Generate")
+  await page.getByRole('button', { name: /Generate for 1\.1\.1/i }).click();
   await expect(page.getByRole('button', { name: /Generate for 1\.1\.1/i })).toBeVisible({
     timeout: 10000,
   });
 
-  // Textarea should now show the AI-generated remarks
-  const textarea = page.getByRole('textbox', { name: /Remarks for 1\.1\.1/i });
-  await expect(textarea).toHaveValue(generatedRemarks);
+  await expect(page.getByRole('textbox', { name: /Remarks for 1\.1\.1/i })).toHaveValue(
+    generatedRemarks
+  );
 });

--- a/e2e/vpat-edit.spec.ts
+++ b/e2e/vpat-edit.spec.ts
@@ -33,7 +33,7 @@ test('single-component: typing remarks and saving persists to view and edit page
       standard_edition: 'WCAG',
       wcag_version: '2.1',
       wcag_level: 'AA',
-      product_scope: ['web'], // single component → standard row layout
+      product_scope: ['web'],
     },
   });
   expect(vpatRes.ok()).toBeTruthy();
@@ -41,7 +41,6 @@ test('single-component: typing remarks and saving persists to view and edit page
 
   await page.goto(`/vpats/${vpatId}/edit`);
   await expect(page.getByRole('heading', { name: 'E2E VPAT Single' })).toBeVisible();
-
   await page.getByRole('tab', { name: 'Level A', exact: true }).click();
 
   const textarea = page.getByRole('textbox', { name: /Remarks for 1\.1\.1/i });
@@ -60,7 +59,6 @@ test('single-component: typing remarks and saving persists to view and edit page
   await page.getByRole('tab', { name: 'Level A', exact: true }).click();
   await expect(page.getByText('Test single')).toBeVisible();
 
-  // Back to edit — value should still be there
   await page.goto(`/vpats/${vpatId}/edit`);
   await page.getByRole('tab', { name: 'Level A', exact: true }).click();
   await expect(page.getByRole('textbox', { name: /Remarks for 1\.1\.1/i })).toHaveValue(
@@ -74,7 +72,6 @@ test('multi-component: typing remarks saves via component API and persists', asy
   page,
   request,
 }) => {
-  // web + software-desktop + documents produces 3 components (web / software / electronic-docs)
   const vpatRes = await request.post('/api/vpats', {
     data: {
       title: 'E2E VPAT Multi',
@@ -90,28 +87,21 @@ test('multi-component: typing remarks saves via component API and persists', asy
 
   await page.goto(`/vpats/${vpatId}/edit`);
   await expect(page.getByRole('heading', { name: 'E2E VPAT Multi' })).toBeVisible();
-
   await page.getByRole('tab', { name: 'Level A', exact: true }).click();
 
-  // The "web" component's remarks textarea for 1.1.1
-  const textarea = page.getByRole('textbox', {
-    name: /Remarks for 1\.1\.1 — web/i,
-  });
+  const textarea = page.getByRole('textbox', { name: /Remarks for 1\.1\.1 — web/i });
   await expect(textarea).toBeVisible();
 
-  // Type and wait for the component PUT to fire
   const putDone = page.waitForResponse(
     (resp) => resp.url().includes('/components/') && resp.request().method() === 'PUT'
   );
   await textarea.fill('Test multi-component');
   await putDone;
 
-  // Navigate to the read-only view and verify the remark shows
   await page.goto(`/vpats/${vpatId}`);
   await page.getByRole('tab', { name: 'Level A', exact: true }).click();
   await expect(page.getByText('Test multi-component')).toBeVisible();
 
-  // Back to edit — textarea should still show the value
   await page.goto(`/vpats/${vpatId}/edit`);
   await page.getByRole('tab', { name: 'Level A', exact: true }).click();
   await expect(page.getByRole('textbox', { name: /Remarks for 1\.1\.1 — web/i })).toHaveValue(
@@ -121,10 +111,10 @@ test('multi-component: typing remarks saves via component API and persists', asy
 
 // ─── AI generation ───────────────────────────────────────────────────────────
 
-test('AI generation updates the textarea with generated remarks', async ({ page, request }) => {
+test('AI generation (single-component): updates the textarea', async ({ page, request }) => {
   const vpatRes = await request.post('/api/vpats', {
     data: {
-      title: 'E2E VPAT AI',
+      title: 'E2E VPAT AI Single',
       project_id: projectId,
       standard_edition: 'WCAG',
       wcag_version: '2.1',
@@ -135,13 +125,12 @@ test('AI generation updates the textarea with generated remarks', async ({ page,
   expect(vpatRes.ok()).toBeTruthy();
   const vpatId = (await vpatRes.json()).data.id;
 
-  const vpatData = (await (await request.get(`/api/vpats/${vpatId}`)).json()).data;
-  const row111 = vpatData.criterion_rows.find(
-    (r: { criterion_code: string }) => r.criterion_code === '1.1.1'
-  );
+  const row111 = (
+    await (await request.get(`/api/vpats/${vpatId}`)).json()
+  ).data.criterion_rows.find((r: { criterion_code: string }) => r.criterion_code === '1.1.1');
   expect(row111).toBeTruthy();
 
-  const generatedRemarks = 'AI generated: Images must have descriptive alt text.';
+  const generatedRemarks = 'AI: Images must have descriptive alt text.';
 
   await page.route(`/api/vpats/${vpatId}/rows/${row111.id}/generate`, async (route) => {
     await route.fulfill({
@@ -156,6 +145,7 @@ test('AI generation updates the textarea with generated remarks', async ({ page,
           ai_reasoning: 'Based on issues found.',
           ai_suggested_conformance: 'does_not_support',
           ai_referenced_issues: [],
+          components: [],
           last_generated_at: new Date().toISOString(),
           updated_at: new Date().toISOString(),
         },
@@ -164,15 +154,78 @@ test('AI generation updates the textarea with generated remarks', async ({ page,
   });
 
   await page.goto(`/vpats/${vpatId}/edit`);
-  await expect(page.getByRole('heading', { name: 'E2E VPAT AI' })).toBeVisible();
   await page.getByRole('tab', { name: 'Level A', exact: true }).click();
+  await page.getByRole('button', { name: /Generate for 1\.1\.1/i }).click();
+  await expect(page.getByRole('button', { name: /Generate for 1\.1\.1/i })).toBeVisible({
+    timeout: 10000,
+  });
+  await expect(page.getByRole('textbox', { name: /Remarks for 1\.1\.1$/i })).toHaveValue(
+    generatedRemarks
+  );
+});
 
+test('AI generation (multi-component): updates all component textareas', async ({
+  page,
+  request,
+}) => {
+  const vpatRes = await request.post('/api/vpats', {
+    data: {
+      title: 'E2E VPAT AI Multi',
+      project_id: projectId,
+      standard_edition: 'WCAG',
+      wcag_version: '2.1',
+      wcag_level: 'AA',
+      product_scope: ['web', 'software-desktop', 'documents'],
+    },
+  });
+  expect(vpatRes.ok()).toBeTruthy();
+  const vpatId = (await vpatRes.json()).data.id;
+
+  const row111 = (
+    await (await request.get(`/api/vpats/${vpatId}`)).json()
+  ).data.criterion_rows.find((r: { criterion_code: string }) => r.criterion_code === '1.1.1');
+  expect(row111).toBeTruthy();
+
+  const generatedRemarks = 'AI: Non-text content must have text alternatives.';
+
+  await page.route(`/api/vpats/${vpatId}/rows/${row111.id}/generate`, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        success: true,
+        data: {
+          ...row111,
+          remarks: generatedRemarks,
+          ai_confidence: 'high',
+          ai_reasoning: 'Based on issues found.',
+          ai_suggested_conformance: 'does_not_support',
+          ai_referenced_issues: [],
+          components: (row111.components ?? []).map((c: { component_name: string }) => ({
+            ...c,
+            remarks: generatedRemarks,
+          })),
+          last_generated_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+        },
+      }),
+    });
+  });
+
+  await page.goto(`/vpats/${vpatId}/edit`);
+  await page.getByRole('tab', { name: 'Level A', exact: true }).click();
   await page.getByRole('button', { name: /Generate for 1\.1\.1/i }).click();
   await expect(page.getByRole('button', { name: /Generate for 1\.1\.1/i })).toBeVisible({
     timeout: 10000,
   });
 
-  await expect(page.getByRole('textbox', { name: /Remarks for 1\.1\.1/i })).toHaveValue(
+  await expect(page.getByRole('textbox', { name: /Remarks for 1\.1\.1 — web/i })).toHaveValue(
     generatedRemarks
   );
+  await expect(page.getByRole('textbox', { name: /Remarks for 1\.1\.1 — software/i })).toHaveValue(
+    generatedRemarks
+  );
+  await expect(
+    page.getByRole('textbox', { name: /Remarks for 1\.1\.1 — electronic-docs/i })
+  ).toHaveValue(generatedRemarks);
 });

--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -10,8 +10,12 @@ export default async function SettingsPage() {
   // The API key is encrypted at rest — pass a masked placeholder if one exists
   const rawApiKey = getSetting('ai_api_key');
   const aiApiKey = rawApiKey ? '[REDACTED]' : '';
-  const aiModel = (getSetting('ai_model') as string) ?? '';
   const aiBaseUrl = (getSetting('ai_base_url') as string) ?? '';
+  const aiModelIssues = (getSetting('ai_model_issues') as string) ?? '';
+  const aiModelVpat = (getSetting('ai_model_vpat') as string) ?? '';
+  const aiModelReports = (getSetting('ai_model_reports') as string) ?? '';
+  const aiModelVpatReview = (getSetting('ai_model_vpat_review') as string) ?? '';
+  const aiReviewPassEnabled = Boolean(getSetting('ai_review_pass_enabled'));
   const authEnabled = Boolean(getSetting('auth_enabled'));
   const users = await getUsers();
 
@@ -31,8 +35,12 @@ export default async function SettingsPage() {
       <SettingsClient
         aiProvider={aiProvider}
         aiApiKey={aiApiKey}
-        aiModel={aiModel}
         aiBaseUrl={aiBaseUrl}
+        aiModelIssues={aiModelIssues}
+        aiModelVpat={aiModelVpat}
+        aiModelReports={aiModelReports}
+        aiModelVpatReview={aiModelVpatReview}
+        aiReviewPassEnabled={aiReviewPassEnabled}
         aiEnvSource={hasAnyEnvOverride ? aiEnvSource : undefined}
         dbPath={process.env.DATABASE_PATH ?? './data/a11y-logger.db'}
         mediaPath="./data/media/"

--- a/src/app/(app)/vpats/[id]/edit/page.tsx
+++ b/src/app/(app)/vpats/[id]/edit/page.tsx
@@ -88,7 +88,10 @@ export default function VpatEditPage() {
   // When update.component_name is set, immediately PUTs to the component API
   // instead of queuing to the row-level PATCH batch.
   const handleRowChange = useCallback(
-    (rowId: string, update: { conformance?: string; component_name?: string }) => {
+    (
+      rowId: string,
+      update: { conformance?: string; remarks?: string; component_name?: string }
+    ) => {
       if (vpat?.status === 'reviewed' && !hasShownEditWarning) {
         setShowEditWarning(true);
       }
@@ -107,6 +110,9 @@ export default function VpatEditPage() {
                           ...(componentUpdate.conformance !== undefined && {
                             conformance:
                               componentUpdate.conformance as VpatCriterionComponent['conformance'],
+                          }),
+                          ...(componentUpdate.remarks !== undefined && {
+                            remarks: componentUpdate.remarks,
                           }),
                         }
                       : c

--- a/src/app/api/ai/generate-issue/__tests__/route.test.ts
+++ b/src/app/api/ai/generate-issue/__tests__/route.test.ts
@@ -15,6 +15,7 @@ const mockProvider = {
   generateReportSection: vi.fn(),
   generateVpatRemarks: vi.fn(),
   generateVpatRow: vi.fn(),
+  reviewVpatRow: vi.fn(),
   generateExecutiveSummaryHtml: vi.fn(),
   testConnection: vi.fn(),
 };

--- a/src/app/api/ai/generate-issue/route.ts
+++ b/src/app/api/ai/generate-issue/route.ts
@@ -19,7 +19,7 @@ interface CurrentFields {
 }
 
 export async function POST(request: Request) {
-  const ai = getAIProvider();
+  const ai = getAIProvider('issues');
   if (!ai) {
     return NextResponse.json(
       { success: false, error: 'AI not configured', code: 'AI_NOT_CONFIGURED' },

--- a/src/app/api/ai/generate-vpat-narrative/__tests__/route.test.ts
+++ b/src/app/api/ai/generate-vpat-narrative/__tests__/route.test.ts
@@ -54,6 +54,7 @@ describe('POST /api/ai/generate-vpat-narrative', () => {
       generateReportSection: vi.fn(),
       generateVpatRemarks: vi.fn(),
       generateVpatRow: vi.fn(),
+      reviewVpatRow: vi.fn(),
       generateExecutiveSummaryHtml: vi.fn(),
       testConnection: vi.fn(),
     });
@@ -77,6 +78,7 @@ describe('POST /api/ai/generate-vpat-narrative', () => {
       generateReportSection: vi.fn(),
       generateVpatRemarks: vi.fn(),
       generateVpatRow: vi.fn(),
+      reviewVpatRow: vi.fn(),
       generateExecutiveSummaryHtml: vi.fn(),
       testConnection: vi.fn(),
     });
@@ -103,6 +105,7 @@ describe('POST /api/ai/generate-vpat-narrative', () => {
       generateReportSection: vi.fn(),
       generateVpatRemarks: mockRemarks,
       generateVpatRow: vi.fn(),
+      reviewVpatRow: vi.fn(),
       generateExecutiveSummaryHtml: vi.fn(),
       testConnection: vi.fn(),
     });
@@ -130,6 +133,7 @@ describe('POST /api/ai/generate-vpat-narrative', () => {
       generateReportSection: vi.fn(),
       generateVpatRemarks: mockRemarks,
       generateVpatRow: vi.fn(),
+      reviewVpatRow: vi.fn(),
       generateExecutiveSummaryHtml: vi.fn(),
       testConnection: vi.fn(),
     });

--- a/src/app/api/ai/generate-vpat-narrative/route.ts
+++ b/src/app/api/ai/generate-vpat-narrative/route.ts
@@ -11,7 +11,7 @@ import { getAssessments } from '@/lib/db/assessments';
 import { getIssues } from '@/lib/db/issues';
 
 export async function POST(request: Request) {
-  const ai = getAIProvider();
+  const ai = getAIProvider('vpat');
   if (!ai) {
     return NextResponse.json(
       { success: false, error: 'AI not configured', code: 'AI_NOT_CONFIGURED' },

--- a/src/app/api/ai/report/executive-summary/route.ts
+++ b/src/app/api/ai/report/executive-summary/route.ts
@@ -9,7 +9,7 @@ import { getAIProvider } from '@/lib/ai';
 import { buildIssueContext } from '../_shared';
 
 export async function POST(request: Request) {
-  const ai = getAIProvider();
+  const ai = getAIProvider('reports');
   if (!ai) {
     return NextResponse.json(
       { success: false, error: 'AI not configured', code: 'AI_NOT_CONFIGURED' },

--- a/src/app/api/ai/report/quick-wins/route.ts
+++ b/src/app/api/ai/report/quick-wins/route.ts
@@ -10,7 +10,7 @@ import { buildIssueContext } from '../_shared';
 import { QUICK_WINS_SECTION } from '@/lib/ai/prompts';
 
 export async function POST(request: Request) {
-  const ai = getAIProvider();
+  const ai = getAIProvider('reports');
   if (!ai) {
     return NextResponse.json(
       { success: false, error: 'AI not configured', code: 'AI_NOT_CONFIGURED' },

--- a/src/app/api/ai/report/top-risks/route.ts
+++ b/src/app/api/ai/report/top-risks/route.ts
@@ -10,7 +10,7 @@ import { buildIssueContext } from '../_shared';
 import { TOP_RISKS_SECTION } from '@/lib/ai/prompts';
 
 export async function POST(request: Request) {
-  const ai = getAIProvider();
+  const ai = getAIProvider('reports');
   if (!ai) {
     return NextResponse.json(
       { success: false, error: 'AI not configured', code: 'AI_NOT_CONFIGURED' },

--- a/src/app/api/ai/report/user-impact/route.ts
+++ b/src/app/api/ai/report/user-impact/route.ts
@@ -10,7 +10,7 @@ import { buildIssueContext } from '../_shared';
 import { buildUserImpactPrompt } from '@/lib/ai/prompts';
 
 export async function POST(request: Request) {
-  const ai = getAIProvider();
+  const ai = getAIProvider('reports');
   if (!ai) {
     return NextResponse.json(
       { success: false, error: 'AI not configured', code: 'AI_NOT_CONFIGURED' },

--- a/src/app/api/ai/test-connection/__tests__/route.test.ts
+++ b/src/app/api/ai/test-connection/__tests__/route.test.ts
@@ -23,6 +23,7 @@ describe('POST /api/ai/test-connection', () => {
       generateReportSection: vi.fn(),
       generateVpatRemarks: vi.fn(),
       generateVpatRow: vi.fn(),
+      reviewVpatRow: vi.fn(),
       generateExecutiveSummaryHtml: vi.fn(),
     });
     const res = await POST();
@@ -38,6 +39,7 @@ describe('POST /api/ai/test-connection', () => {
       generateReportSection: vi.fn(),
       generateVpatRemarks: vi.fn(),
       generateVpatRow: vi.fn(),
+      reviewVpatRow: vi.fn(),
       generateExecutiveSummaryHtml: vi.fn(),
     });
     const res = await POST();

--- a/src/app/api/vpats/[id]/rows/[rowId]/generate/__tests__/route.test.ts
+++ b/src/app/api/vpats/[id]/rows/[rowId]/generate/__tests__/route.test.ts
@@ -5,6 +5,15 @@ import { createProject } from '@/lib/db/projects';
 import { createVpat } from '@/lib/db/vpats';
 import { getCriterionRows } from '@/lib/db/vpat-criterion-rows';
 import { POST } from '../route';
+import { getAIProvider } from '@/lib/ai';
+import { getSetting } from '@/lib/db/settings';
+
+const mockGetAIProvider = vi.mocked(getAIProvider);
+const mockGetSetting = vi.mocked(getSetting);
+
+vi.mock('@/lib/ai', () => ({
+  getAIProvider: vi.fn(),
+}));
 
 vi.mock('@/lib/db/settings', () => ({
   getSetting: vi.fn().mockReturnValue(null),
@@ -60,8 +69,7 @@ describe('POST /api/vpats/[id]/rows/[rowId]/generate', () => {
   });
 
   it('returns 404 for unknown row', async () => {
-    vi.stubEnv('AI_PROVIDER', 'openai');
-    vi.stubEnv('AI_API_KEY', 'test-key');
+    mockGetAIProvider.mockReturnValue({ generateVpatRow: vi.fn() } as never);
     const res = await POST(new Request('http://localhost/', { method: 'POST' }), {
       params: Promise.resolve({ id: vpatId, rowId: 'unknown-row-id' }),
     });
@@ -71,8 +79,7 @@ describe('POST /api/vpats/[id]/rows/[rowId]/generate', () => {
   });
 
   it('returns 404 for unknown VPAT', async () => {
-    vi.stubEnv('AI_PROVIDER', 'openai');
-    vi.stubEnv('AI_API_KEY', 'test-key');
+    mockGetAIProvider.mockReturnValue({ generateVpatRow: vi.fn() } as never);
     const res = await POST(new Request('http://localhost/', { method: 'POST' }), {
       params: Promise.resolve({ id: 'unknown-vpat-id', rowId }),
     });
@@ -82,8 +89,7 @@ describe('POST /api/vpats/[id]/rows/[rowId]/generate', () => {
   });
 
   it('returns 404 when row belongs to different VPAT', async () => {
-    vi.stubEnv('AI_PROVIDER', 'openai');
-    vi.stubEnv('AI_API_KEY', 'test-key');
+    mockGetAIProvider.mockReturnValue({ generateVpatRow: vi.fn() } as never);
     const otherProject = await createProject({ name: 'Other' });
     const otherVpat = await createVpat({
       title: 'Other',
@@ -100,19 +106,16 @@ describe('POST /api/vpats/[id]/rows/[rowId]/generate', () => {
   });
 
   it('returns updated row after successful generation', async () => {
-    vi.stubEnv('AI_PROVIDER', 'openai');
-    vi.stubEnv('AI_API_KEY', 'test-key');
-
-    const { generateText } = await import('ai');
-    vi.mocked(generateText).mockResolvedValue({
-      text: JSON.stringify({
-        reasoning: 'No issues found.',
-        remarks: 'The product supports this criterion.',
-        confidence: 'high',
-        referenced_issues: [],
-        suggested_conformance: 'supports',
-      }),
-    } as Awaited<ReturnType<typeof generateText>>);
+    const firstPassResult = {
+      remarks: 'The product supports this criterion.',
+      confidence: 'high' as const,
+      reasoning: 'No issues found.',
+      referenced_issues: [],
+      suggested_conformance: 'supports' as const,
+    };
+    mockGetAIProvider.mockReturnValue({
+      generateVpatRow: vi.fn().mockResolvedValue(firstPassResult),
+    } as never);
 
     const res = await POST(new Request('http://localhost/', { method: 'POST' }), {
       params: Promise.resolve({ id: vpatId, rowId }),
@@ -128,19 +131,16 @@ describe('POST /api/vpats/[id]/rows/[rowId]/generate', () => {
   });
 
   it('stores referenced issues as snapshot', async () => {
-    vi.stubEnv('AI_PROVIDER', 'openai');
-    vi.stubEnv('AI_API_KEY', 'test-key');
-
-    const { generateText } = await import('ai');
-    vi.mocked(generateText).mockResolvedValue({
-      text: JSON.stringify({
-        reasoning: 'One issue found.',
-        remarks: 'Does not support.',
-        confidence: 'high',
-        referenced_issues: [{ title: 'Missing alt', severity: 'high' }],
-        suggested_conformance: 'does_not_support',
-      }),
-    } as Awaited<ReturnType<typeof generateText>>);
+    const firstPassResult = {
+      remarks: 'Does not support.',
+      confidence: 'high' as const,
+      reasoning: 'One issue found.',
+      referenced_issues: [{ title: 'Missing alt', severity: 'high' }],
+      suggested_conformance: 'does_not_support' as const,
+    };
+    mockGetAIProvider.mockReturnValue({
+      generateVpatRow: vi.fn().mockResolvedValue(firstPassResult),
+    } as never);
 
     const res = await POST(new Request('http://localhost/', { method: 'POST' }), {
       params: Promise.resolve({ id: vpatId, rowId }),
@@ -149,5 +149,76 @@ describe('POST /api/vpats/[id]/rows/[rowId]/generate', () => {
     const body = await res.json();
     expect(body.data.ai_referenced_issues).toEqual([{ title: 'Missing alt', severity: 'high' }]);
     expect(body.data.ai_suggested_conformance).toBe('does_not_support');
+  });
+});
+
+describe('POST generate — AI Review Pass', () => {
+  const firstPassResult = {
+    remarks: 'Does not support.',
+    confidence: 'medium' as const,
+    reasoning: 'One issue.',
+    referenced_issues: [{ title: 'Missing alt', severity: 'high' }],
+    suggested_conformance: 'does_not_support' as const,
+  };
+  const reviewedResult = {
+    remarks: 'Does not support 1.1.1.',
+    confidence: 'high' as const,
+    reasoning: 'Reviewed: correct.',
+    referenced_issues: [{ title: 'Missing alt', severity: 'high' }],
+    suggested_conformance: 'does_not_support' as const,
+  };
+
+  it('does not call reviewVpatRow when ai_review_pass_enabled is false', async () => {
+    mockGetSetting.mockImplementation((key: string) => {
+      if (key === 'ai_review_pass_enabled') return false;
+      return null;
+    });
+    const reviewVpatRow = vi.fn();
+    vi.mocked(getAIProvider).mockReturnValueOnce({
+      generateVpatRow: vi.fn().mockResolvedValue(firstPassResult),
+      reviewVpatRow,
+    } as never);
+
+    const req = new Request('http://localhost', { method: 'POST' });
+    await POST(req, { params: Promise.resolve({ id: vpatId, rowId }) });
+
+    expect(reviewVpatRow).not.toHaveBeenCalled();
+  });
+
+  it('calls reviewVpatRow when ai_review_pass_enabled is true and review provider is available', async () => {
+    mockGetSetting.mockImplementation((key: string) => {
+      if (key === 'ai_review_pass_enabled') return true;
+      return null;
+    });
+    const reviewVpatRow = vi.fn().mockResolvedValue(reviewedResult);
+    vi.mocked(getAIProvider)
+      .mockReturnValueOnce({ generateVpatRow: vi.fn().mockResolvedValue(firstPassResult) } as never)
+      .mockReturnValueOnce({ reviewVpatRow } as never);
+
+    const req = new Request('http://localhost', { method: 'POST' });
+    const res = await POST(req, { params: Promise.resolve({ id: vpatId, rowId }) });
+    const json = await res.json();
+
+    expect(json.success).toBe(true);
+    expect(reviewVpatRow).toHaveBeenCalledWith(
+      expect.objectContaining({ criterion: expect.any(Object) }),
+      firstPassResult
+    );
+  });
+
+  it('uses first-pass result when review provider is null', async () => {
+    mockGetSetting.mockImplementation((key: string) => {
+      if (key === 'ai_review_pass_enabled') return true;
+      return null;
+    });
+    vi.mocked(getAIProvider)
+      .mockReturnValueOnce({ generateVpatRow: vi.fn().mockResolvedValue(firstPassResult) } as never)
+      .mockReturnValueOnce(null);
+
+    const req = new Request('http://localhost', { method: 'POST' });
+    const res = await POST(req, { params: Promise.resolve({ id: vpatId, rowId }) });
+    const json = await res.json();
+
+    expect(json.success).toBe(true);
   });
 });

--- a/src/app/api/vpats/[id]/rows/[rowId]/generate/route.ts
+++ b/src/app/api/vpats/[id]/rows/[rowId]/generate/route.ts
@@ -8,6 +8,7 @@ import { NextResponse } from 'next/server';
 import { getCriterionRow, updateCriterionRow } from '@/lib/db/vpat-criterion-rows';
 import { getVpat } from '@/lib/db/vpats';
 import { getDb } from '@/lib/db';
+import { getSetting } from '@/lib/db/settings';
 import { getAIProvider } from '@/lib/ai';
 
 type RouteContext = { params: Promise<{ id: string; rowId: string }> };
@@ -15,7 +16,7 @@ type RouteContext = { params: Promise<{ id: string; rowId: string }> };
 export async function POST(_request: Request, { params }: RouteContext) {
   const { id: vpatId, rowId } = await params;
 
-  const ai = getAIProvider();
+  const ai = getAIProvider('vpat');
   if (!ai) {
     return NextResponse.json(
       { success: false, error: 'No AI provider configured', code: 'NO_AI_PROVIDER' },
@@ -37,7 +38,6 @@ export async function POST(_request: Request, { params }: RouteContext) {
       { status: 404 }
     );
 
-  // Fetch issues matched to this criterion from the associated project
   const issues = getDb()
     .prepare(
       `
@@ -60,20 +60,29 @@ export async function POST(_request: Request, { params }: RouteContext) {
     description: string;
   }[];
 
-  // Build a lookup map for enriching AI-referenced issues with their IDs after generation
   const issueByTitle = new Map(issues.map((i) => [i.title, i]));
 
-  try {
-    const result = await ai.generateVpatRow({
-      criterion: {
-        code: row.criterion_code,
-        name: row.criterion_name,
-        description: row.criterion_description,
-      },
-      issues,
-    });
+  const context = {
+    criterion: {
+      code: row.criterion_code,
+      name: row.criterion_name,
+      description: row.criterion_description,
+    },
+    issues,
+  };
 
-    // Enrich referenced issues with IDs so the UI can link to them
+  try {
+    let result = await ai.generateVpatRow(context);
+
+    // Optional AI Review Pass — uses a separate model slot
+    const reviewEnabled = getSetting('ai_review_pass_enabled');
+    if (reviewEnabled) {
+      const reviewer = getAIProvider('vpat_review');
+      if (reviewer) {
+        result = await reviewer.reviewVpatRow(context, result);
+      }
+    }
+
     const enrichedReferencedIssues = result.referenced_issues.map((ref) => {
       const match = issueByTitle.get(ref.title);
       if (match) {

--- a/src/app/api/vpats/[id]/rows/[rowId]/generate/route.ts
+++ b/src/app/api/vpats/[id]/rows/[rowId]/generate/route.ts
@@ -5,7 +5,11 @@
  */
 
 import { NextResponse } from 'next/server';
-import { getCriterionRow, updateCriterionRow } from '@/lib/db/vpat-criterion-rows';
+import {
+  getCriterionRow,
+  updateCriterionRow,
+  upsertCriterionComponent,
+} from '@/lib/db/vpat-criterion-rows';
 import { getVpat } from '@/lib/db/vpats';
 import { getDb } from '@/lib/db';
 import { getSetting } from '@/lib/db/settings';
@@ -103,6 +107,19 @@ export async function POST(_request: Request, { params }: RouteContext) {
       ai_referenced_issues: enrichedReferencedIssues,
       ai_suggested_conformance: result.suggested_conformance,
     });
+
+    // For multi-component rows, distribute the generated remarks to every component
+    // so the per-component textareas in the UI reflect the AI output.
+    const components = updated?.components ?? [];
+    if (components.length > 1) {
+      for (const comp of components) {
+        await upsertCriterionComponent(rowId, comp.component_name, {
+          remarks: result.remarks,
+        });
+      }
+      const withComponents = await getCriterionRow(rowId);
+      return NextResponse.json({ success: true, data: withComponents });
+    }
 
     return NextResponse.json({ success: true, data: updated });
   } catch {

--- a/src/app/api/vpats/[id]/rows/generate-all/__tests__/route.test.ts
+++ b/src/app/api/vpats/[id]/rows/generate-all/__tests__/route.test.ts
@@ -5,6 +5,14 @@ import { createProject } from '@/lib/db/projects';
 import { createVpat } from '@/lib/db/vpats';
 import { updateCriterionRow, getCriterionRows } from '@/lib/db/vpat-criterion-rows';
 import { POST } from '../route';
+import { getAIProvider } from '@/lib/ai';
+import { getSetting } from '@/lib/db/settings';
+
+const mockGetSetting = vi.mocked(getSetting);
+
+vi.mock('@/lib/ai', () => ({
+  getAIProvider: vi.fn(),
+}));
 
 vi.mock('@/lib/db/settings', () => ({
   getSetting: vi.fn().mockReturnValue(null),
@@ -13,11 +21,6 @@ vi.mock('@/lib/db/settings', () => ({
   deleteSetting: vi.fn(),
   seedDefaultSettings: vi.fn(),
 }));
-
-vi.mock('ai', async (importOriginal) => {
-  const original = await importOriginal<typeof import('ai')>();
-  return { ...original, generateText: vi.fn() };
-});
 
 let vpatId: string;
 
@@ -57,8 +60,7 @@ describe('POST /api/vpats/[id]/rows/generate-all', () => {
   });
 
   it('returns 404 for unknown VPAT', async () => {
-    vi.stubEnv('AI_PROVIDER', 'openai');
-    vi.stubEnv('AI_API_KEY', 'test-key');
+    vi.mocked(getAIProvider).mockReturnValue({ generateVpatRow: vi.fn() } as never);
     const res = await POST(new Request('http://localhost/', { method: 'POST' }), {
       params: Promise.resolve({ id: 'unknown-vpat-id' }),
     });
@@ -68,24 +70,18 @@ describe('POST /api/vpats/[id]/rows/generate-all', () => {
   });
 
   it('skips rows that already have remarks and counts them correctly', async () => {
-    vi.stubEnv('AI_PROVIDER', 'openai');
-    vi.stubEnv('AI_API_KEY', 'test-key');
-
-    // Pre-fill the first row with remarks
     const rows = await getCriterionRows(vpatId);
     await updateCriterionRow(rows[0]!.id, { remarks: 'Already filled.' });
 
-    // Mock generateText to succeed
-    const { generateText } = await import('ai');
-    vi.mocked(generateText).mockResolvedValue({
-      text: JSON.stringify({
+    vi.mocked(getAIProvider).mockReturnValue({
+      generateVpatRow: vi.fn().mockResolvedValue({
         reasoning: 'Test',
         remarks: 'Generated remark.',
         confidence: 'medium',
         referenced_issues: [],
         suggested_conformance: 'supports',
       }),
-    } as Awaited<ReturnType<typeof generateText>>);
+    } as never);
 
     const res = await POST(new Request('http://localhost/', { method: 'POST' }), {
       params: Promise.resolve({ id: vpatId }),
@@ -99,25 +95,21 @@ describe('POST /api/vpats/[id]/rows/generate-all', () => {
   });
 
   it('accumulates errors for failed AI calls and counts correctly', async () => {
-    vi.stubEnv('AI_PROVIDER', 'openai');
-    vi.stubEnv('AI_API_KEY', 'test-key');
-
     const rows = await getCriterionRows(vpatId);
     let callCount = 0;
-    const { generateText } = await import('ai');
-    vi.mocked(generateText).mockImplementation(async () => {
-      callCount++;
-      if (callCount === 1) throw new Error('Network error');
-      return {
-        text: JSON.stringify({
+    vi.mocked(getAIProvider).mockReturnValue({
+      generateVpatRow: vi.fn().mockImplementation(async () => {
+        callCount++;
+        if (callCount === 1) throw new Error('Network error');
+        return {
           reasoning: 'r',
           remarks: 'Generated.',
           confidence: 'medium',
           referenced_issues: [],
           suggested_conformance: 'supports',
-        }),
-      } as Awaited<ReturnType<typeof generateText>>;
-    });
+        };
+      }),
+    } as never);
 
     const res = await POST(new Request('http://localhost/', { method: 'POST' }), {
       params: Promise.resolve({ id: vpatId }),
@@ -127,5 +119,56 @@ describe('POST /api/vpats/[id]/rows/generate-all', () => {
     expect(body.data.errors).toHaveLength(1);
     expect(body.data.generated).toBe(rows.length - 1);
     expect(body.data.skipped).toBe(0);
+  });
+});
+
+describe('POST generate-all — AI Review Pass', () => {
+  const firstPassResult = {
+    remarks: 'First pass.',
+    confidence: 'medium' as const,
+    reasoning: 'OK.',
+    referenced_issues: [],
+    suggested_conformance: 'supports' as const,
+  };
+  const reviewedResult = {
+    remarks: 'Reviewed.',
+    confidence: 'high' as const,
+    reasoning: 'OK.',
+    referenced_issues: [],
+    suggested_conformance: 'supports' as const,
+  };
+
+  it('calls reviewVpatRow for each row when review pass is enabled and provider is available', async () => {
+    mockGetSetting.mockImplementation((key: string) => {
+      if (key === 'ai_review_pass_enabled') return true;
+      return null;
+    });
+    const reviewVpatRow = vi.fn().mockResolvedValue(reviewedResult);
+    vi.mocked(getAIProvider)
+      .mockReturnValueOnce({ generateVpatRow: vi.fn().mockResolvedValue(firstPassResult) } as never)
+      .mockReturnValueOnce({ reviewVpatRow } as never);
+
+    const req = new Request('http://localhost', { method: 'POST' });
+    const res = await POST(req, { params: Promise.resolve({ id: vpatId }) });
+    const json = await res.json();
+
+    expect(json.success).toBe(true);
+    expect(reviewVpatRow).toHaveBeenCalled();
+  });
+
+  it('skips review pass when review provider is null', async () => {
+    mockGetSetting.mockImplementation((key: string) => {
+      if (key === 'ai_review_pass_enabled') return true;
+      return null;
+    });
+    vi.mocked(getAIProvider)
+      .mockReturnValueOnce({ generateVpatRow: vi.fn().mockResolvedValue(firstPassResult) } as never)
+      .mockReturnValueOnce(null);
+
+    const req = new Request('http://localhost', { method: 'POST' });
+    const res = await POST(req, { params: Promise.resolve({ id: vpatId }) });
+    const json = await res.json();
+
+    expect(json.success).toBe(true);
   });
 });

--- a/src/app/api/vpats/[id]/rows/generate-all/route.ts
+++ b/src/app/api/vpats/[id]/rows/generate-all/route.ts
@@ -8,14 +8,16 @@ import { NextResponse } from 'next/server';
 import { getCriterionRows, updateCriterionRow } from '@/lib/db/vpat-criterion-rows';
 import { getVpat } from '@/lib/db/vpats';
 import { getDb } from '@/lib/db';
+import { getSetting } from '@/lib/db/settings';
 import { getAIProvider } from '@/lib/ai';
+import type { VpatGenerationContext, VpatRowGenerationResult } from '@/lib/ai';
 
 type RouteContext = { params: Promise<{ id: string }> };
 
 export async function POST(_request: Request, { params }: RouteContext) {
   const { id: vpatId } = await params;
 
-  const ai = getAIProvider();
+  const ai = getAIProvider('vpat');
   if (!ai) {
     return NextResponse.json(
       { success: false, error: 'No AI provider configured', code: 'NO_AI_PROVIDER' },
@@ -30,15 +32,17 @@ export async function POST(_request: Request, { params }: RouteContext) {
       { status: 404 }
     );
 
-  // Skip rows that already have remarks text
   const allRows = await getCriterionRows(vpatId);
   const rows = allRows.filter((r) => !r.remarks);
+
+  const reviewEnabled = getSetting('ai_review_pass_enabled');
+  const reviewer = reviewEnabled ? getAIProvider('vpat_review') : null;
 
   let generated = 0;
   const errors: string[] = [];
 
   const stmt = getDb().prepare(`
-    SELECT i.title, i.severity, i.url, i.description
+    SELECT i.id, i.assessment_id, i.title, i.severity, i.url, i.description
     FROM issues i JOIN assessments a ON i.assessment_id = a.id
     WHERE a.project_id = ? AND i.status = 'open'
       AND EXISTS (SELECT 1 FROM json_each(i.wcag_codes) WHERE value = ?)
@@ -46,25 +50,36 @@ export async function POST(_request: Request, { params }: RouteContext) {
 
   for (const row of rows) {
     const issues = stmt.all(vpat.project_id, row.criterion_code) as {
+      id: string;
+      assessment_id: string;
       title: string;
       severity: string;
       url: string;
       description: string;
     }[];
 
+    const context: VpatGenerationContext = {
+      criterion: {
+        code: row.criterion_code,
+        name: row.criterion_name,
+        description: row.criterion_description,
+      },
+      issues,
+    };
+
     try {
-      const result = await ai.generateVpatRow({
-        criterion: {
-          code: row.criterion_code,
-          name: row.criterion_name,
-          description: row.criterion_description,
-        },
-        issues,
-      });
+      let result: VpatRowGenerationResult = await ai.generateVpatRow(context);
+
+      if (reviewer) {
+        result = await reviewer.reviewVpatRow(context, result);
+      }
+
       await updateCriterionRow(row.id, {
         remarks: result.remarks,
         ai_confidence: result.confidence,
         ai_reasoning: result.reasoning,
+        ai_referenced_issues: result.referenced_issues,
+        ai_suggested_conformance: result.suggested_conformance,
       });
       generated++;
     } catch {

--- a/src/app/api/vpats/[id]/rows/generate-all/route.ts
+++ b/src/app/api/vpats/[id]/rows/generate-all/route.ts
@@ -74,11 +74,25 @@ export async function POST(_request: Request, { params }: RouteContext) {
         result = await reviewer.reviewVpatRow(context, result);
       }
 
+      const issueByTitle = new Map(issues.map((i) => [i.title, i]));
+      const enrichedReferencedIssues = result.referenced_issues.map((ref) => {
+        const match = issueByTitle.get(ref.title);
+        if (match) {
+          return {
+            ...ref,
+            id: match.id,
+            assessment_id: match.assessment_id,
+            project_id: vpat.project_id,
+          };
+        }
+        return ref;
+      });
+
       await updateCriterionRow(row.id, {
         remarks: result.remarks,
         ai_confidence: result.confidence,
         ai_reasoning: result.reasoning,
-        ai_referenced_issues: result.referenced_issues,
+        ai_referenced_issues: enrichedReferencedIssues,
         ai_suggested_conformance: result.suggested_conformance,
       });
       generated++;

--- a/src/components/settings/__tests__/ai-config-section.test.tsx
+++ b/src/components/settings/__tests__/ai-config-section.test.tsx
@@ -64,7 +64,7 @@ describe('AIConfigSection — env var overrides', () => {
     expect(screen.getByText(/set via environment variable/i)).toBeInTheDocument();
   });
 
-  it('shows env model value in model field when model is from env', () => {
+  it('shows env override banner when model is from env', () => {
     render(
       <AIConfigSection
         provider="ollama"
@@ -72,9 +72,9 @@ describe('AIConfigSection — env var overrides', () => {
         envSource={{ provider: null, apiKey: false, model: 'llama3.2', baseUrl: null }}
       />
     );
-    const modelInput = screen.getByLabelText(/model name/i);
-    expect(modelInput).toHaveValue('llama3.2');
-    expect(modelInput).toBeDisabled();
+    // The per-task model selectors are shown; the env banner is shown because model is set
+    const alert = screen.getByRole('alert');
+    expect(alert).toBeInTheDocument();
   });
 
   it('shows env baseUrl value in base URL field when baseUrl is from env', () => {
@@ -93,5 +93,102 @@ describe('AIConfigSection — env var overrides', () => {
     const baseUrlInput = screen.getByLabelText(/base url/i);
     expect(baseUrlInput).toHaveValue('http://localhost:11434/v1');
     expect(baseUrlInput).toBeDisabled();
+  });
+});
+
+describe('AIConfigSection — per-task model selectors', () => {
+  const onSave = vi.fn().mockResolvedValue(undefined);
+
+  it('shows task model section when provider is openai', () => {
+    render(
+      <AIConfigSection
+        provider="openai"
+        onSave={onSave}
+        modelIssues=""
+        modelVpat=""
+        modelReports=""
+        modelVpatReview=""
+        reviewPassEnabled={false}
+      />
+    );
+    expect(screen.getByText('Issue Analysis')).toBeInTheDocument();
+    expect(screen.getByText('VPAT Generation')).toBeInTheDocument();
+    expect(screen.getByText('Report Writing')).toBeInTheDocument();
+    expect(screen.getByText('AI Review Pass')).toBeInTheDocument();
+  });
+
+  it('does not show review model selector when toggle is off', () => {
+    render(
+      <AIConfigSection
+        provider="openai"
+        onSave={onSave}
+        modelIssues=""
+        modelVpat=""
+        modelReports=""
+        modelVpatReview=""
+        reviewPassEnabled={false}
+      />
+    );
+    expect(screen.queryByLabelText(/ai review pass model/i)).not.toBeInTheDocument();
+  });
+
+  it('shows review model selector when toggle is switched on', async () => {
+    const user = userEvent.setup();
+    render(
+      <AIConfigSection
+        provider="openai"
+        onSave={onSave}
+        modelIssues=""
+        modelVpat=""
+        modelReports=""
+        modelVpatReview=""
+        reviewPassEnabled={false}
+      />
+    );
+    await user.click(screen.getByRole('switch', { name: /enable ai review pass/i }));
+    expect(screen.getByLabelText(/ai review pass model/i)).toBeInTheDocument();
+  });
+
+  it('calls onSave with all model fields and reviewPassEnabled', async () => {
+    const user = userEvent.setup();
+    const mockSave = vi.fn().mockResolvedValue(undefined);
+    render(
+      <AIConfigSection
+        provider="openai"
+        onSave={mockSave}
+        modelIssues="gpt-4o"
+        modelVpat="gpt-4o-mini"
+        modelReports=""
+        modelVpatReview=""
+        reviewPassEnabled={true}
+      />
+    );
+    await user.click(screen.getByRole('button', { name: 'Save Configuration' }));
+    await waitFor(() => {
+      expect(mockSave).toHaveBeenCalledWith(
+        expect.objectContaining({
+          modelIssues: 'gpt-4o',
+          modelVpat: 'gpt-4o-mini',
+          modelReports: '',
+          modelVpatReview: '',
+          reviewPassEnabled: true,
+        })
+      );
+    });
+  });
+
+  it('hides task model section when provider is none', () => {
+    render(
+      <AIConfigSection
+        provider="none"
+        onSave={onSave}
+        modelIssues=""
+        modelVpat=""
+        modelReports=""
+        modelVpatReview=""
+        reviewPassEnabled={false}
+      />
+    );
+    expect(screen.queryByText('Issue Analysis')).not.toBeInTheDocument();
   });
 });

--- a/src/components/settings/__tests__/ai-config-section.test.tsx
+++ b/src/components/settings/__tests__/ai-config-section.test.tsx
@@ -11,9 +11,9 @@ describe('AIConfigSection — None provider', () => {
     expect(screen.getByRole('button', { name: 'Save Configuration' })).not.toBeDisabled();
   });
 
-  it('Save button is disabled when no provider is selected', () => {
+  it('Save button is always enabled regardless of provider selection', () => {
     render(<AIConfigSection provider="" onSave={onSave} />);
-    expect(screen.getByRole('button', { name: 'Save Configuration' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Save Configuration' })).not.toBeDisabled();
   });
 
   it('calls onSave with provider=none when None is saved', async () => {
@@ -54,9 +54,9 @@ describe('AIConfigSection — env var overrides', () => {
     expect(screen.queryByRole('alert')).not.toBeInTheDocument();
   });
 
-  it('disables Save button when provider is from env', () => {
+  it('Save button remains enabled even when provider is from env', () => {
     render(<AIConfigSection provider="none" onSave={onSave} envSource={envSource} />);
-    expect(screen.getByRole('button', { name: 'Save Configuration' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Save Configuration' })).not.toBeDisabled();
   });
 
   it('shows "Set via environment variable" for API key when apiKey is from env', () => {

--- a/src/components/settings/ai-config-section.tsx
+++ b/src/components/settings/ai-config-section.tsx
@@ -1,9 +1,11 @@
 'use client';
+
 import { useState } from 'react';
 import { Eye, EyeOff, Info } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
 import {
   Select,
   SelectContent,
@@ -12,6 +14,7 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { KNOWN_MODELS, AI_TASKS } from '@/lib/ai/models';
 
 interface AIEnvSource {
   provider: string | null;
@@ -23,14 +26,22 @@ interface AIEnvSource {
 interface AIConfigSectionProps {
   provider?: string;
   apiKey?: string;
-  model?: string;
   baseUrl?: string;
+  modelIssues?: string;
+  modelVpat?: string;
+  modelReports?: string;
+  modelVpatReview?: string;
+  reviewPassEnabled?: boolean;
   envSource?: AIEnvSource;
   onSave: (data: {
     provider: string;
     apiKey: string;
-    model: string;
     baseUrl: string;
+    modelIssues: string;
+    modelVpat: string;
+    modelReports: string;
+    modelVpatReview: string;
+    reviewPassEnabled: boolean;
   }) => Promise<void>;
 }
 
@@ -43,31 +54,122 @@ const PROVIDERS = [
   { value: 'openai-compatible', label: 'OpenAI-compatible (custom)' },
 ];
 
-const MODEL_PLACEHOLDERS: Record<string, string> = {
-  openai: 'gpt-4o-mini',
-  anthropic: 'claude-haiku-4-5-20251001',
-  google: 'gemini-2.0-flash',
-  ollama: 'llama3.2',
-  'openai-compatible': 'model-name',
-};
-
 const needsApiKey = (p: string) =>
   ['openai', 'anthropic', 'google', 'openai-compatible'].includes(p);
 const needsBaseUrl = (p: string) => ['ollama', 'openai-compatible'].includes(p);
-const needsModel = (p: string) => ['ollama', 'openai-compatible'].includes(p);
+
+// ─── TaskModelSelector ────────────────────────────────────────────────────────
+
+interface TaskModelSelectorProps {
+  id: string;
+  label: string;
+  description: string;
+  provider: string;
+  value: string;
+  onChange: (v: string) => void;
+  disabled?: boolean;
+}
+
+function TaskModelSelector({
+  id,
+  label,
+  description,
+  provider,
+  value,
+  onChange,
+  disabled,
+}: TaskModelSelectorProps) {
+  const knownModels = KNOWN_MODELS[provider] ?? [];
+  const isCustomValue = value !== '' && !knownModels.some((m) => m.value === value);
+  const [showOther, setShowOther] = useState(isCustomValue);
+
+  const PROVIDER_DEFAULT = '__default__';
+  const dropdownValue = showOther ? 'other' : value === '' ? PROVIDER_DEFAULT : value;
+
+  return (
+    <div className="space-y-1.5">
+      <Label htmlFor={id}>{label}</Label>
+      <p className="text-xs text-muted-foreground">{description}</p>
+      {knownModels.length > 0 ? (
+        <>
+          <Select
+            value={dropdownValue}
+            onValueChange={(v) => {
+              if (v === 'other') {
+                setShowOther(true);
+                onChange('');
+              } else if (v === PROVIDER_DEFAULT) {
+                setShowOther(false);
+                onChange('');
+              } else {
+                setShowOther(false);
+                onChange(v);
+              }
+            }}
+            disabled={disabled}
+          >
+            <SelectTrigger id={id} aria-label={label}>
+              <SelectValue placeholder="Provider default" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={PROVIDER_DEFAULT}>Provider default</SelectItem>
+              {knownModels.map((m) => (
+                <SelectItem key={m.value} value={m.value}>
+                  {m.label}
+                </SelectItem>
+              ))}
+              <SelectItem value="other">Other…</SelectItem>
+            </SelectContent>
+          </Select>
+          {showOther && (
+            <Input
+              id={`${id}-other`}
+              value={value}
+              onChange={(e) => onChange(e.target.value)}
+              disabled={disabled}
+              placeholder="model-name"
+              aria-label={`${label} custom model name`}
+            />
+          )}
+        </>
+      ) : (
+        <Input
+          id={id}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          disabled={disabled}
+          placeholder="model-name"
+          aria-label={label}
+        />
+      )}
+    </div>
+  );
+}
+
+// ─── AIConfigSection ──────────────────────────────────────────────────────────
 
 export function AIConfigSection({
   provider = '',
   apiKey = '',
-  model = '',
   baseUrl = '',
+  modelIssues = '',
+  modelVpat = '',
+  modelReports = '',
+  modelVpatReview = '',
+  reviewPassEnabled = false,
   envSource,
   onSave,
 }: AIConfigSectionProps) {
   const [selectedProvider, setSelectedProvider] = useState(envSource?.provider ?? provider);
   const [key, setKey] = useState(apiKey);
-  const [selectedModel, setSelectedModel] = useState(envSource?.model ?? model);
   const [selectedBaseUrl, setSelectedBaseUrl] = useState(envSource?.baseUrl ?? baseUrl);
+  const [models, setModels] = useState({
+    issues: modelIssues,
+    vpat: modelVpat,
+    reports: modelReports,
+    vpat_review: modelVpatReview,
+  });
+  const [reviewEnabled, setReviewEnabled] = useState(reviewPassEnabled);
   const [showKey, setShowKey] = useState(false);
   const [loading, setLoading] = useState(false);
 
@@ -85,13 +187,19 @@ export function AIConfigSection({
       await onSave({
         provider: selectedProvider,
         apiKey: key,
-        model: selectedModel,
         baseUrl: selectedBaseUrl,
+        modelIssues: models.issues,
+        modelVpat: models.vpat,
+        modelReports: models.reports,
+        modelVpatReview: models.vpat_review,
+        reviewPassEnabled: reviewEnabled,
       });
     } finally {
       setLoading(false);
     }
   };
+
+  const showTaskModels = selectedProvider && selectedProvider !== 'none';
 
   return (
     <Card>
@@ -117,6 +225,7 @@ export function AIConfigSection({
           </div>
         )}
 
+        {/* Provider */}
         <div className="space-y-1.5">
           <Label htmlFor="ai-provider">
             AI Provider
@@ -142,12 +251,13 @@ export function AIConfigSection({
 
         {selectedProvider === 'openai-compatible' && (
           <p className="text-sm text-muted-foreground">
-            Any API that follows the OpenAI chat format works here. That includes Groq, Together AI,
-            LM Studio, and most self-hosted models. Point it at the base URL, pick a model name, and
-            it will behave the same as OpenAI.
+            Any API that follows the OpenAI chat format works here — Groq, Together AI, LM Studio,
+            and most self-hosted models. Point it at the base URL, pick a model name, and it will
+            behave the same as OpenAI.
           </p>
         )}
 
+        {/* API Key */}
         {needsApiKey(selectedProvider) && (
           <div className="space-y-1.5">
             <Label htmlFor="api-key">
@@ -183,6 +293,7 @@ export function AIConfigSection({
           </div>
         )}
 
+        {/* Base URL */}
         {needsBaseUrl(selectedProvider) && (
           <div className="space-y-1.5">
             <Label htmlFor="base-url">
@@ -204,19 +315,60 @@ export function AIConfigSection({
           </div>
         )}
 
-        {needsModel(selectedProvider) && (
-          <div className="space-y-1.5">
-            <Label htmlFor="ai-model">
-              Model Name
-              {envSource?.model && <EnvBadge />}
-            </Label>
-            <Input
-              id="ai-model"
-              value={selectedModel}
-              onChange={(e) => setSelectedModel(e.target.value)}
-              disabled={!!envSource?.model}
-              placeholder={MODEL_PLACEHOLDERS[selectedProvider] ?? 'model-name'}
-            />
+        {/* Per-task model selectors */}
+        {showTaskModels && (
+          <div className="space-y-4 border-t pt-4">
+            <p className="text-sm font-medium">Model per Task</p>
+            <p className="text-xs text-muted-foreground">
+              Choose which model to use for each task. Leave a task on &quot;Provider default&quot;
+              to use the model your provider selects automatically.
+            </p>
+
+            {AI_TASKS.filter((t) => t.key !== 'vpat_review').map((task) => (
+              <TaskModelSelector
+                key={task.key}
+                id={`ai-model-${task.key}`}
+                label={task.label}
+                description={task.description}
+                provider={selectedProvider}
+                value={models[task.key as keyof typeof models]}
+                onChange={(v) => setModels((prev) => ({ ...prev, [task.key]: v }))}
+              />
+            ))}
+
+            {/* AI Review Pass section */}
+            <div className="border-t pt-4 space-y-3">
+              <p className="text-sm font-medium">AI Review Pass</p>
+              <div className="flex items-center justify-between">
+                <div className="space-y-0.5">
+                  <Label htmlFor="review-pass-toggle" className="text-sm">
+                    Enable AI Review Pass
+                  </Label>
+                  <p className="text-xs text-muted-foreground">
+                    After generating a VPAT criterion row, a second AI call reviews the result and
+                    corrects the conformance call if the evidence does not support it. This doubles
+                    the number of AI calls for VPAT generation.
+                  </p>
+                </div>
+                <Switch
+                  id="review-pass-toggle"
+                  checked={reviewEnabled}
+                  onCheckedChange={setReviewEnabled}
+                  aria-label="Enable AI Review Pass"
+                />
+              </div>
+
+              {reviewEnabled && (
+                <TaskModelSelector
+                  id="ai-model-vpat-review"
+                  label="AI Review Pass Model"
+                  description="Used for the review critique pass. A smaller, faster model often works well here."
+                  provider={selectedProvider}
+                  value={models.vpat_review}
+                  onChange={(v) => setModels((prev) => ({ ...prev, vpat_review: v }))}
+                />
+              )}
+            </div>
           </div>
         )}
 

--- a/src/components/settings/ai-config-section.tsx
+++ b/src/components/settings/ai-config-section.tsx
@@ -182,6 +182,7 @@ export function AIConfigSection({
   const providerFromEnv = !!envSource?.provider;
 
   const handleSave = async () => {
+    if (loading) return;
     setLoading(true);
     try {
       await onSave({
@@ -372,9 +373,7 @@ export function AIConfigSection({
           </div>
         )}
 
-        <Button onClick={handleSave} disabled={loading || !selectedProvider || providerFromEnv}>
-          {loading ? 'Saving…' : 'Save Configuration'}
-        </Button>
+        <Button onClick={handleSave}>{loading ? 'Saving…' : 'Save Configuration'}</Button>
       </CardContent>
     </Card>
   );

--- a/src/components/settings/settings-client.tsx
+++ b/src/components/settings/settings-client.tsx
@@ -17,8 +17,12 @@ interface AIEnvSource {
 interface SettingsClientProps {
   aiProvider: string;
   aiApiKey: string;
-  aiModel: string;
   aiBaseUrl: string;
+  aiModelIssues: string;
+  aiModelVpat: string;
+  aiModelReports: string;
+  aiModelVpatReview: string;
+  aiReviewPassEnabled: boolean;
   aiEnvSource?: AIEnvSource;
   dbPath: string;
   mediaPath: string;
@@ -36,8 +40,12 @@ interface SettingsClientProps {
 export function SettingsClient({
   aiProvider,
   aiApiKey,
-  aiModel,
   aiBaseUrl,
+  aiModelIssues,
+  aiModelVpat,
+  aiModelReports,
+  aiModelVpatReview,
+  aiReviewPassEnabled,
   aiEnvSource,
   dbPath,
   mediaPath,
@@ -48,44 +56,67 @@ export function SettingsClient({
   const handleSaveAI = async (data: {
     provider: string;
     apiKey: string;
-    model: string;
     baseUrl: string;
+    modelIssues: string;
+    modelVpat: string;
+    modelReports: string;
+    modelVpatReview: string;
+    reviewPassEnabled: boolean;
   }) => {
     try {
-      const providerRes = await fetch('/api/settings/ai_provider', {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ value: data.provider }),
-      });
-      const providerJson = await providerRes.json();
-      if (!providerJson.success) throw new Error(providerJson.error);
+      const saves: Promise<Response>[] = [
+        fetch('/api/settings/ai_provider', {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ value: data.provider }),
+        }),
+        fetch('/api/settings/ai_base_url', {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ value: data.baseUrl }),
+        }),
+        fetch('/api/settings/ai_model_issues', {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ value: data.modelIssues }),
+        }),
+        fetch('/api/settings/ai_model_vpat', {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ value: data.modelVpat }),
+        }),
+        fetch('/api/settings/ai_model_reports', {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ value: data.modelReports }),
+        }),
+        fetch('/api/settings/ai_model_vpat_review', {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ value: data.modelVpatReview }),
+        }),
+        fetch('/api/settings/ai_review_pass_enabled', {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ value: data.reviewPassEnabled }),
+        }),
+      ];
 
       // Only update API key if it's not the redacted placeholder
       if (data.apiKey !== '[REDACTED]') {
-        const keyRes = await fetch('/api/settings/ai_api_key', {
-          method: 'PUT',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ value: data.apiKey }),
-        });
-        const keyJson = await keyRes.json();
-        if (!keyJson.success) throw new Error(keyJson.error);
+        saves.push(
+          fetch('/api/settings/ai_api_key', {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ value: data.apiKey }),
+          })
+        );
       }
 
-      const modelRes = await fetch('/api/settings/ai_model', {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ value: data.model }),
-      });
-      const modelJson = await modelRes.json();
-      if (!modelJson.success) throw new Error(modelJson.error);
-
-      const baseUrlRes = await fetch('/api/settings/ai_base_url', {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ value: data.baseUrl }),
-      });
-      const baseUrlJson = await baseUrlRes.json();
-      if (!baseUrlJson.success) throw new Error(baseUrlJson.error);
+      const results = await Promise.all(saves);
+      const jsons = await Promise.all(results.map((r) => r.json()));
+      const failed = jsons.find((j: { success: boolean; error?: string }) => !j.success);
+      if (failed) throw new Error((failed as { error?: string }).error);
 
       toast.success('AI configuration saved');
     } catch {
@@ -105,8 +136,12 @@ export function SettingsClient({
         <AIConfigSection
           provider={aiProvider}
           apiKey={aiApiKey}
-          model={aiModel}
           baseUrl={aiBaseUrl}
+          modelIssues={aiModelIssues}
+          modelVpat={aiModelVpat}
+          modelReports={aiModelReports}
+          modelVpatReview={aiModelVpatReview}
+          reviewPassEnabled={aiReviewPassEnabled}
           envSource={aiEnvSource}
           onSave={handleSaveAI}
         />

--- a/src/components/vpats/__tests__/vpat-criteria-row-multicomponent.test.tsx
+++ b/src/components/vpats/__tests__/vpat-criteria-row-multicomponent.test.tsx
@@ -161,6 +161,52 @@ describe('VpatCriteriaRow — multi-component', () => {
     expect(screen.getByLabelText('Conformance for 1.1.1 — electronic-docs')).toBeDefined();
   });
 
+  it('renders Generate button for multi-component row when aiEnabled', () => {
+    const row = {
+      id: 'row1',
+      vpat_id: 'vpat1',
+      criterion_code: '1.1.1',
+      criterion_name: 'Non-text Content',
+      criterion_description: '',
+      criterion_name_translated: null,
+      section: 'wcag',
+      conformance: 'not_evaluated',
+      remarks: null,
+      issue_count: 0,
+      ai_confidence: null,
+      ai_reasoning: null,
+      ai_suggested_conformance: null,
+      ai_referenced_issues: null,
+      last_generated_at: null,
+      components: [
+        { component_name: 'Web', conformance: 'not_evaluated', remarks: null },
+        { component_name: 'Docs', conformance: 'not_evaluated', remarks: null },
+      ],
+    };
+    const onGenerateRow = vi.fn();
+    render(
+      <table>
+        <tbody>
+          <VpatCriteriaRow
+            row={row as never}
+            isEven={false}
+            readOnly={false}
+            aiEnabled={true}
+            isGenerating={false}
+            isGeneratingAll={false}
+            onRowChange={vi.fn()}
+            scheduleRemarksSave={vi.fn()}
+            onGenerateRow={onGenerateRow}
+            register={vi
+              .fn()
+              .mockReturnValue({ ref: vi.fn(), name: 'row1', onChange: vi.fn(), onBlur: vi.fn() })}
+          />
+        </tbody>
+      </table>
+    );
+    expect(screen.getByRole('button', { name: /generate for 1\.1\.1/i })).toBeInTheDocument();
+  });
+
   it('renders in readOnly mode without throwing', () => {
     const row = makeRow({
       components: [

--- a/src/components/vpats/__tests__/vpat-criteria-table.test.tsx
+++ b/src/components/vpats/__tests__/vpat-criteria-table.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import { VpatCriteriaTable } from '@/components/vpats/vpat-criteria-table';
 import type { VpatCriterionRow } from '@/lib/db/vpat-criterion-rows';
@@ -346,5 +346,77 @@ describe('VpatCriteriaTable', () => {
     vi.runAllTimers();
     expect(onSaveRemarks).toHaveBeenCalledWith('1', 'New remark');
     vi.useRealTimers();
+  });
+
+  it('closes the AI panel when the close button is clicked', () => {
+    render(
+      <VpatCriteriaTable
+        rows={[makeRow({ ai_confidence: 'high', remarks: 'text' })]}
+        onRowChange={vi.fn()}
+        onSaveRemarks={vi.fn()}
+        onGenerateRow={vi.fn()}
+        aiEnabled
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /ai info for 1.1.1/i }));
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /^close$/i }));
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('renders single section when sectionKey is provided', () => {
+    const rows = [
+      makeRow({
+        id: '1',
+        criterion_code: '1.1.1',
+        criterion_level: 'A',
+        criterion_section: 'Perceivable',
+      }),
+      makeRow({
+        id: '2',
+        criterion_code: '2.1.1',
+        criterion_level: 'A',
+        criterion_section: 'Operable',
+      }),
+    ];
+    render(
+      <VpatCriteriaTable rows={rows} onRowChange={vi.fn()} onSaveRemarks={vi.fn()} sectionKey="A" />
+    );
+    // Only the one card for Level A — no standard group headings
+    expect(screen.queryByRole('heading', { name: /wcag/i })).not.toBeInTheDocument();
+    expect(screen.getByTestId('row-1')).toBeInTheDocument();
+    expect(screen.getByTestId('row-2')).toBeInTheDocument();
+  });
+
+  it('shows "No criteria" message when sectionKey matches no rows', () => {
+    render(
+      <VpatCriteriaTable
+        rows={[makeRow()]}
+        onRowChange={vi.fn()}
+        onSaveRemarks={vi.fn()}
+        sectionKey="AAA"
+      />
+    );
+    expect(screen.getByText(/no criteria in this section/i)).toBeInTheDocument();
+  });
+
+  it('syncs form values when row remarks change externally', () => {
+    const row = makeRow({ remarks: 'initial' });
+    const { rerender } = render(
+      <VpatCriteriaTable rows={[row]} onRowChange={vi.fn()} onSaveRemarks={vi.fn()} />
+    );
+    const textarea = screen.getByRole('textbox', { name: /remarks for 1.1.1/i });
+    expect(textarea).toHaveValue('initial');
+
+    act(() => {
+      rerender(
+        <VpatCriteriaTable
+          rows={[{ ...row, remarks: 'updated externally' }]}
+          onRowChange={vi.fn()}
+          onSaveRemarks={vi.fn()}
+        />
+      );
+    });
+    expect(textarea).toHaveValue('updated externally');
   });
 });

--- a/src/components/vpats/vpat-criteria-row.tsx
+++ b/src/components/vpats/vpat-criteria-row.tsx
@@ -188,6 +188,39 @@ export const VpatCriteriaRow = memo(function VpatCriteriaRow({
               </tbody>
             </table>
           </TableCell>
+          {aiEnabled && !readOnly && (
+            <TableCell className="align-top pt-3 text-center">
+              <div className="flex items-center justify-center gap-1">
+                <Button
+                  type="button"
+                  variant="ai"
+                  size="sm"
+                  onClick={() => onGenerateRow?.(row.id)}
+                  disabled={isDisabled}
+                  aria-label={
+                    isGenerating
+                      ? `Generating for ${row.criterion_code}`
+                      : `Generate for ${row.criterion_code}`
+                  }
+                >
+                  <Sparkles />
+                  {isGenerating ? 'Generating…' : 'Generate'}
+                </Button>
+                {hasAiInfo && (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    className="h-8 w-8 p-0"
+                    onClick={() => onAiInfoClick?.(row)}
+                    aria-label={`AI info for ${row.criterion_code}`}
+                  >
+                    <Info className="h-4 w-4" />
+                  </Button>
+                )}
+              </div>
+            </TableCell>
+          )}
         </TableRow>
       </>
     );

--- a/src/components/vpats/vpat-criteria-row.tsx
+++ b/src/components/vpats/vpat-criteria-row.tsx
@@ -73,9 +73,15 @@ export const VpatCriteriaRow = memo(function VpatCriteriaRow({
     el.style.height = `${el.scrollHeight}px`;
   }, []);
 
-  // Resize after row.remarks changes — rAF lets the parent's setValue update the DOM first.
+  // Sync textarea value when row.remarks changes externally (e.g. AI generation).
+  // Direct DOM update is more reliable than relying on RHF setValue from the parent.
   useEffect(() => {
-    requestAnimationFrame(() => autoResize(textareaRef.current));
+    const el = textareaRef.current;
+    if (!el) return;
+    if (el.value !== (row.remarks ?? '')) {
+      el.value = row.remarks ?? '';
+    }
+    requestAnimationFrame(() => autoResize(el));
   }, [row.remarks, autoResize]);
 
   const isUnresolved = row.conformance === 'not_evaluated';

--- a/src/components/vpats/vpat-criteria-row.tsx
+++ b/src/components/vpats/vpat-criteria-row.tsx
@@ -67,6 +67,7 @@ export const VpatCriteriaRow = memo(function VpatCriteriaRow({
   );
 
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const compRemarkRefs = useRef<Map<string, HTMLTextAreaElement>>(new Map());
   const autoResize = useCallback((el: HTMLTextAreaElement | null) => {
     if (!el) return;
     el.style.height = 'auto';
@@ -83,6 +84,17 @@ export const VpatCriteriaRow = memo(function VpatCriteriaRow({
     }
     requestAnimationFrame(() => autoResize(el));
   }, [row.remarks, autoResize]);
+
+  // Sync per-component textarea values when component remarks change externally (AI generation).
+  useEffect(() => {
+    (row.components ?? []).forEach((comp) => {
+      const el = compRemarkRefs.current.get(comp.component_name);
+      if (el && el.value !== (comp.remarks ?? '')) {
+        el.value = comp.remarks ?? '';
+        requestAnimationFrame(() => autoResize(el));
+      }
+    });
+  }, [row.components, autoResize]);
 
   const isUnresolved = row.conformance === 'not_evaluated';
   const conformanceLabel =
@@ -178,6 +190,10 @@ export const VpatCriteriaRow = memo(function VpatCriteriaRow({
                           </span>
                         ) : (
                           <Textarea
+                            ref={(el) => {
+                              if (el) compRemarkRefs.current.set(comp.component_name, el);
+                              else compRemarkRefs.current.delete(comp.component_name);
+                            }}
                             className="text-sm min-h-10 overflow-hidden"
                             style={{ resize: 'vertical' }}
                             placeholder="Add remarks…"

--- a/src/components/vpats/vpat-criteria-row.tsx
+++ b/src/components/vpats/vpat-criteria-row.tsx
@@ -34,7 +34,7 @@ export interface VpatCriteriaRowProps {
   isGenerating: boolean;
   isGeneratingAll: boolean;
   onRowChange: (rowId: string, update: { conformance?: string; component_name?: string }) => void;
-  scheduleRemarksSave: (rowId: string, value: string) => void;
+  scheduleRemarksSave: (rowId: string, value: string, componentName?: string) => void;
   onGenerateRow?: (rowId: string) => void;
   onCriterionClick?: (criterionCode: string) => void;
   onAiInfoClick?: (row: VpatCriterionRow) => void;
@@ -123,7 +123,6 @@ export const VpatCriteriaRow = memo(function VpatCriteriaRow({
   );
 
   if (isMultiComponent) {
-    const colSpan = aiEnabled && !readOnly ? 5 : 4;
     return (
       <>
         <TableRow
@@ -132,7 +131,7 @@ export const VpatCriteriaRow = memo(function VpatCriteriaRow({
         >
           <TableCell className="font-mono text-sm align-top pt-3">{row.criterion_code}</TableCell>
           {criterionNameCell}
-          <TableCell colSpan={colSpan - 2} className="p-0">
+          <TableCell colSpan={2} className="p-0">
             <table data-testid="component-sub-table" className="w-full">
               <tbody>
                 {(row.components ?? []).map((comp) => {
@@ -184,6 +183,9 @@ export const VpatCriteriaRow = memo(function VpatCriteriaRow({
                             placeholder="Add remarks…"
                             disabled={isDisabled}
                             defaultValue={comp.remarks ?? ''}
+                            onChange={(e) =>
+                              scheduleRemarksSave(row.id, e.target.value, comp.component_name)
+                            }
                             aria-label={`Remarks for ${row.criterion_code} — ${comp.component_name}`}
                           />
                         )}

--- a/src/components/vpats/vpat-criteria-table.tsx
+++ b/src/components/vpats/vpat-criteria-table.tsx
@@ -57,8 +57,11 @@ interface CriterionSectionProps {
   aiEnabled: boolean;
   generatingRowId?: string | null;
   isGeneratingAll: boolean;
-  onRowChange: (rowId: string, update: { conformance?: string }) => void;
-  scheduleRemarksSave: (rowId: string, value: string) => void;
+  onRowChange: (
+    rowId: string,
+    update: { conformance?: string; remarks?: string; component_name?: string }
+  ) => void;
+  scheduleRemarksSave: (rowId: string, value: string, componentName?: string) => void;
   onGenerateRow?: (rowId: string) => void;
   onCriterionClick?: (criterionCode: string) => void;
   onAiInfoClick?: (row: VpatCriterionRow) => void;
@@ -153,9 +156,12 @@ const CriterionSection = memo(function CriterionSection({
 interface VpatCriteriaTableProps {
   rows: VpatCriterionRow[];
   locale?: string;
-  /** Called immediately for conformance changes (updates progress bar in parent). */
-  onRowChange: (rowId: string, update: { conformance?: string }) => void;
-  /** Called after 500ms debounce when the user finishes typing remarks. */
+  /** Called immediately for conformance changes; for components also handles debounced remarks. */
+  onRowChange: (
+    rowId: string,
+    update: { conformance?: string; remarks?: string; component_name?: string }
+  ) => void;
+  /** Called after 500ms debounce when the user finishes typing remarks on a single-component row. */
   onSaveRemarks: (rowId: string, remarks: string) => void;
   onGenerateRow?: (rowId: string) => void;
   onGenerateAll?: () => void;
@@ -244,16 +250,25 @@ export function VpatCriteriaTable({
 
   // Reset the timer for this row on every keystroke so only the final value
   // after the user pauses is written to the database.
+  // For multi-component rows, componentName is passed and the save goes through
+  // onRowChange (which calls the component API directly) instead of the batch queue.
   const scheduleRemarksSave = useCallback(
-    (rowId: string, value: string) => {
-      const existing = saveTimers.current.get(rowId);
+    (rowId: string, value: string, componentName?: string) => {
+      const timerKey = componentName ? `${rowId}::${componentName}` : rowId;
+      const existing = saveTimers.current.get(timerKey);
       if (existing) clearTimeout(existing);
       saveTimers.current.set(
-        rowId,
-        setTimeout(() => onSaveRemarks(rowId, value), 500)
+        timerKey,
+        setTimeout(() => {
+          if (componentName) {
+            onRowChange(rowId, { remarks: value, component_name: componentName });
+          } else {
+            onSaveRemarks(rowId, value);
+          }
+        }, 500)
       );
     },
-    [onSaveRemarks]
+    [onSaveRemarks, onRowChange]
   );
 
   // Group rows: WCAG rows by criterion_level (A/AA/AAA), all others by criterion_section.

--- a/src/lib/ai/__tests__/prompts.test.ts
+++ b/src/lib/ai/__tests__/prompts.test.ts
@@ -13,6 +13,8 @@ import {
   buildVpatRowPrompt,
   parseVpatRowResponse,
 } from '../prompts';
+import { buildVpatReviewPrompt } from '../prompts';
+import type { VpatGenerationContext, VpatRowGenerationResult } from '../types';
 
 describe('system prompt constants', () => {
   it('ANALYZE_ISSUE_SYSTEM contains key instructions', () => {
@@ -208,5 +210,57 @@ describe('parseVpatRowResponse', () => {
         })
       )
     ).toThrow('AI response missing required fields');
+  });
+});
+
+describe('buildVpatReviewPrompt', () => {
+  const context: VpatGenerationContext = {
+    criterion: {
+      code: '1.1.1',
+      name: 'Non-text Content',
+      description: 'Provide text alternatives.',
+    },
+    issues: [
+      {
+        title: 'Missing alt',
+        severity: 'high',
+        url: 'https://example.com',
+        description: 'No alt.',
+      },
+    ],
+  };
+  const firstPass: VpatRowGenerationResult = {
+    remarks: 'Does not support 1.1.1.',
+    confidence: 'high',
+    reasoning: 'One high severity issue found.',
+    referenced_issues: [{ title: 'Missing alt', severity: 'high' }],
+    suggested_conformance: 'does_not_support',
+  };
+
+  it('includes the criterion code and name', () => {
+    const prompt = buildVpatReviewPrompt(context, firstPass);
+    expect(prompt).toContain('1.1.1');
+    expect(prompt).toContain('Non-text Content');
+  });
+
+  it('includes the first-pass conformance and remarks', () => {
+    const prompt = buildVpatReviewPrompt(context, firstPass);
+    expect(prompt).toContain('does_not_support');
+    expect(prompt).toContain('Does not support 1.1.1.');
+  });
+
+  it('instructs the model to return valid JSON', () => {
+    const prompt = buildVpatReviewPrompt(context, firstPass);
+    expect(prompt).toContain('Return only valid JSON');
+  });
+
+  it('includes issue count in the prompt', () => {
+    const prompt = buildVpatReviewPrompt(context, firstPass);
+    expect(prompt).toContain('1 total');
+  });
+
+  it('shows "No issues" text when issues array is empty', () => {
+    const prompt = buildVpatReviewPrompt({ ...context, issues: [] }, firstPass);
+    expect(prompt).toContain('No issues mapped');
   });
 });

--- a/src/lib/ai/__tests__/providers.test.ts
+++ b/src/lib/ai/__tests__/providers.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { getAIProvider } from '../index';
 import { getSetting } from '@/lib/db/settings';
 import { VercelAIProvider } from '../vercel-provider';
@@ -6,6 +6,21 @@ import { VercelAIProvider } from '../vercel-provider';
 vi.mock('@/lib/db/settings', () => ({
   getSetting: vi.fn(),
 }));
+
+vi.mock('@ai-sdk/openai', () => ({
+  createOpenAI: vi.fn(() => vi.fn(() => 'openai-model')),
+}));
+vi.mock('@ai-sdk/anthropic', () => ({
+  createAnthropic: vi.fn(() => vi.fn(() => 'anthropic-model')),
+}));
+vi.mock('@ai-sdk/google', () => ({
+  createGoogleGenerativeAI: vi.fn(() => vi.fn(() => 'google-model')),
+}));
+
+import { createOpenAI } from '@ai-sdk/openai';
+
+const mockGetSetting = vi.mocked(getSetting);
+const mockCreateOpenAI = vi.mocked(createOpenAI);
 
 describe('getAIProvider (updated)', () => {
   beforeEach(() => {
@@ -115,5 +130,87 @@ describe('getAIProvider (updated)', () => {
       key === 'ai_provider' ? 'unknown-provider' : null
     );
     expect(getAIProvider()).toBeNull();
+  });
+});
+
+describe('getAIProvider — task-based model resolution', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env.AI_PROVIDER;
+    delete process.env.AI_API_KEY;
+    delete process.env.AI_MODEL;
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('uses task-specific model setting when set', () => {
+    mockGetSetting.mockImplementation((key) => {
+      if (key === 'ai_provider') return 'openai';
+      if (key === 'ai_api_key') return 'sk-test';
+      if (key === 'ai_model_vpat') return 'gpt-4o';
+      if (key === 'ai_model') return '';
+      return null;
+    });
+    const modelFn = vi.fn(() => 'resolved-model');
+    mockCreateOpenAI.mockReturnValue(modelFn as never);
+
+    getAIProvider('vpat');
+
+    expect(modelFn).toHaveBeenCalledWith('gpt-4o');
+  });
+
+  it('falls back to ai_model when task model is empty', () => {
+    mockGetSetting.mockImplementation((key) => {
+      if (key === 'ai_provider') return 'openai';
+      if (key === 'ai_api_key') return 'sk-test';
+      if (key === 'ai_model_vpat') return '';
+      if (key === 'ai_model') return 'gpt-4o-mini';
+      return null;
+    });
+    const modelFn = vi.fn(() => 'resolved-model');
+    mockCreateOpenAI.mockReturnValue(modelFn as never);
+
+    getAIProvider('vpat');
+
+    expect(modelFn).toHaveBeenCalledWith('gpt-4o-mini');
+  });
+
+  it('uses provider default when both task model and ai_model are empty', () => {
+    mockGetSetting.mockImplementation((key) => {
+      if (key === 'ai_provider') return 'openai';
+      if (key === 'ai_api_key') return 'sk-test';
+      return '';
+    });
+    const modelFn = vi.fn(() => 'resolved-model');
+    mockCreateOpenAI.mockReturnValue(modelFn as never);
+
+    getAIProvider('vpat');
+
+    expect(modelFn).toHaveBeenCalledWith('gpt-4o-mini');
+  });
+
+  it('returns null when no provider is set', () => {
+    mockGetSetting.mockReturnValue('none');
+    expect(getAIProvider('vpat')).toBeNull();
+  });
+
+  it('behaves identically with no task argument (backward compat)', () => {
+    mockGetSetting.mockImplementation((key) => {
+      if (key === 'ai_provider') return 'openai';
+      if (key === 'ai_api_key') return 'sk-test';
+      if (key === 'ai_model') return 'gpt-4o-mini';
+      return '';
+    });
+    const modelFn = vi.fn(() => 'resolved-model');
+    mockCreateOpenAI.mockReturnValue(modelFn as never);
+
+    getAIProvider();
+
+    expect(modelFn).toHaveBeenCalledWith('gpt-4o-mini');
   });
 });

--- a/src/lib/ai/__tests__/vercel-provider.test.ts
+++ b/src/lib/ai/__tests__/vercel-provider.test.ts
@@ -149,3 +149,61 @@ describe('VercelAIProvider.generateVpatRow', () => {
     expect(result.confidence).toBe('medium');
   });
 });
+
+describe('VercelAIProvider.reviewVpatRow', () => {
+  const context = {
+    criterion: {
+      code: '1.1.1',
+      name: 'Non-text Content',
+      description: 'Provide text alternatives.',
+    },
+    issues: [
+      {
+        title: 'Missing alt',
+        severity: 'high',
+        url: 'https://example.com',
+        description: 'No alt.',
+      },
+    ],
+  };
+  const firstPass = {
+    remarks: 'Does not support.',
+    confidence: 'medium' as const,
+    reasoning: 'One high issue.',
+    referenced_issues: [{ title: 'Missing alt', severity: 'high' }],
+    suggested_conformance: 'does_not_support' as const,
+  };
+  const reviewedResult = {
+    remarks: 'Does not support 1.1.1 due to missing alt text.',
+    confidence: 'high' as const,
+    reasoning: 'First pass was correct.',
+    referenced_issues: [{ title: 'Missing alt', severity: 'high' }],
+    suggested_conformance: 'does_not_support' as const,
+  };
+
+  it('returns parsed VpatRowGenerationResult on valid JSON', async () => {
+    mockGenerateText.mockResolvedValue({ text: JSON.stringify(reviewedResult) } as never);
+    const provider = new VercelAIProvider(fakeModel);
+    const result = await provider.reviewVpatRow(context, firstPass);
+    expect(result.remarks).toBe('Does not support 1.1.1 due to missing alt text.');
+    expect(result.suggested_conformance).toBe('does_not_support');
+  });
+
+  it('throws on invalid JSON', async () => {
+    mockGenerateText.mockResolvedValue({ text: 'not json' } as never);
+    const provider = new VercelAIProvider(fakeModel);
+    await expect(provider.reviewVpatRow(context, firstPass)).rejects.toThrow(
+      'Invalid response from AI provider'
+    );
+  });
+
+  it('throws when required fields are missing', async () => {
+    mockGenerateText.mockResolvedValue({
+      text: JSON.stringify({ remarks: 'only remarks' }),
+    } as never);
+    const provider = new VercelAIProvider(fakeModel);
+    await expect(provider.reviewVpatRow(context, firstPass)).rejects.toThrow(
+      'AI response missing required fields'
+    );
+  });
+});

--- a/src/lib/ai/index.ts
+++ b/src/lib/ai/index.ts
@@ -3,30 +3,22 @@ import { createAnthropic } from '@ai-sdk/anthropic';
 import { createGoogleGenerativeAI } from '@ai-sdk/google';
 import { getSetting } from '@/lib/db/settings';
 import { VercelAIProvider } from './vercel-provider';
+import { TASK_MODEL_SETTINGS } from './models';
 import type { AIProvider } from './types';
+import type { AITask } from './models';
 
 /**
- * Resolves and returns the configured AI provider, or `null` if none is active.
+ * Resolves and returns the configured AI provider for the given task, or `null` if none is active.
  *
- * Supports BYOK (Bring Your Own Key) for OpenAI, Anthropic, and Google Gemini, plus
- * Ollama for local models and a generic OpenAI-compatible endpoint. Configuration is
- * read from environment variables first (`AI_PROVIDER`, `AI_API_KEY`, `AI_MODEL`,
- * `AI_BASE_URL`), falling back to values stored in the application settings table.
+ * Model resolution order (first non-empty wins):
+ *   1. `AI_MODEL` env var
+ *   2. Task-specific setting (e.g. `ai_model_vpat`) if `task` is provided
+ *   3. Global `ai_model` setting (legacy fallback)
+ *   4. Hardcoded provider default (e.g. gpt-4o-mini for OpenAI)
  *
- * Provider selection:
- * - `"openai"` — requires `AI_API_KEY`; defaults to `gpt-4o-mini`.
- * - `"anthropic"` — requires `AI_API_KEY`; defaults to `claude-haiku-4-5-20251001`.
- * - `"google"` — requires `AI_API_KEY`; defaults to `gemini-2.0-flash`.
- * - `"ollama"` — requires `AI_MODEL`; defaults base URL to `http://localhost:11434/v1`.
- * - `"openai-compatible"` — requires both `AI_BASE_URL` and `AI_MODEL`.
- * - `"none"` or unset — returns `null`.
- *
- * All providers are wrapped in `VercelAIProvider` which implements the `AIProvider` interface.
- *
- * @returns An `AIProvider` instance if a valid provider is configured, or `null` otherwise.
+ * Provider and API key are read from env vars first, then DB settings.
  */
-export function getAIProvider(): AIProvider | null {
-  // Env vars take priority over DB settings
+export function getAIProvider(task?: AITask): AIProvider | null {
   const provider = (
     process.env.AI_PROVIDER ??
     (getSetting('ai_provider') as string | null) ??
@@ -34,10 +26,13 @@ export function getAIProvider(): AIProvider | null {
   ).toLowerCase();
 
   const apiKey = process.env.AI_API_KEY ?? (getSetting('ai_api_key') as string | null) ?? '';
-
-  const model = process.env.AI_MODEL ?? (getSetting('ai_model') as string | null) ?? '';
-
   const baseUrl = process.env.AI_BASE_URL ?? (getSetting('ai_base_url') as string | null) ?? '';
+
+  // Task-specific model > env var > global ai_model fallback
+  const taskModelKey = task ? TASK_MODEL_SETTINGS[task] : null;
+  const taskModel = taskModelKey ? ((getSetting(taskModelKey) as string | null) ?? '') : '';
+  const model =
+    process.env.AI_MODEL ?? (taskModel || ((getSetting('ai_model') as string | null) ?? ''));
 
   if (!provider || provider === 'none') return null;
 

--- a/src/lib/ai/index.ts
+++ b/src/lib/ai/index.ts
@@ -28,7 +28,7 @@ export function getAIProvider(task?: AITask): AIProvider | null {
   const apiKey = process.env.AI_API_KEY ?? (getSetting('ai_api_key') as string | null) ?? '';
   const baseUrl = process.env.AI_BASE_URL ?? (getSetting('ai_base_url') as string | null) ?? '';
 
-  // Task-specific model > env var > global ai_model fallback
+  // env var > task-specific setting > global ai_model fallback > provider default
   const taskModelKey = task ? TASK_MODEL_SETTINGS[task] : null;
   const taskModel = taskModelKey ? ((getSetting(taskModelKey) as string | null) ?? '') : '';
   const model =

--- a/src/lib/ai/models.ts
+++ b/src/lib/ai/models.ts
@@ -1,0 +1,57 @@
+// src/lib/ai/models.ts
+
+export const KNOWN_MODELS: Record<string, { value: string; label: string }[]> = {
+  openai: [
+    { value: 'gpt-4o', label: 'GPT-4o' },
+    { value: 'gpt-4o-mini', label: 'GPT-4o Mini' },
+    { value: 'o3-mini', label: 'o3 Mini' },
+    { value: 'o1-mini', label: 'o1 Mini' },
+  ],
+  anthropic: [
+    { value: 'claude-opus-4-6', label: 'Claude Opus 4.6' },
+    { value: 'claude-sonnet-4-6', label: 'Claude Sonnet 4.6' },
+    { value: 'claude-haiku-4-5-20251001', label: 'Claude Haiku 4.5' },
+  ],
+  google: [
+    { value: 'gemini-2.0-flash', label: 'Gemini 2.0 Flash' },
+    { value: 'gemini-1.5-pro', label: 'Gemini 1.5 Pro' },
+    { value: 'gemini-1.5-flash', label: 'Gemini 1.5 Flash' },
+  ],
+};
+
+export const AI_TASKS = [
+  {
+    key: 'issues' as const,
+    settingKey: 'ai_model_issues',
+    label: 'Issue Analysis',
+    description:
+      'Used when analyzing pasted issue text to extract title, severity, WCAG codes, and suggested fixes.',
+  },
+  {
+    key: 'vpat' as const,
+    settingKey: 'ai_model_vpat',
+    label: 'VPAT Generation',
+    description:
+      'Used when generating conformance remarks and suggested conformance levels for VPAT criterion rows.',
+  },
+  {
+    key: 'reports' as const,
+    settingKey: 'ai_model_reports',
+    label: 'Report Writing',
+    description:
+      'Used when generating executive summaries and narrative sections in accessibility audit reports.',
+  },
+  {
+    key: 'vpat_review' as const,
+    settingKey: 'ai_model_vpat_review',
+    label: 'AI Review Pass',
+    description:
+      'Used for the optional second critique pass on VPAT generation. Reviews the first result and corrects the conformance call if the evidence does not support it.',
+  },
+] as const;
+
+export type AITask = (typeof AI_TASKS)[number]['key'];
+
+export const TASK_MODEL_SETTINGS: Record<AITask, string> = Object.fromEntries(
+  AI_TASKS.map((t) => [t.key, t.settingKey])
+) as Record<AITask, string>;

--- a/src/lib/ai/prompts.ts
+++ b/src/lib/ai/prompts.ts
@@ -149,6 +149,54 @@ Return only valid JSON, no markdown.`;
 }
 
 /**
+ * Builds a review prompt that asks the AI to critique and correct a first-pass VPAT row result.
+ *
+ * @param context - The original criterion metadata and mapped issues.
+ * @param firstPass - The result produced by the first-pass `generateVpatRow` call.
+ * @returns A formatted prompt string ready to send to a language model.
+ */
+export function buildVpatReviewPrompt(
+  context: VpatGenerationContext,
+  firstPass: VpatRowGenerationResult
+): string {
+  const { criterion, issues } = context;
+  const issueList =
+    issues.length > 0
+      ? issues.map((i) => `- [${i.severity}] ${i.title}`).join('\n')
+      : 'No issues mapped to this criterion.';
+
+  return `You are reviewing a VPAT conformance remark written by another AI. Your job is to verify the conformance call and correct it if the evidence does not support it.
+
+Criterion: ${criterion.code} — ${criterion.name}
+Description: ${criterion.description}
+
+Mapped issues (${issues.length} total):
+${issueList}
+
+First-pass result:
+- Suggested conformance: ${firstPass.suggested_conformance}
+- Confidence: ${firstPass.confidence}
+- Remarks: ${firstPass.remarks}
+- Reasoning: ${firstPass.reasoning}
+
+Review the first-pass result:
+1. Does the suggested_conformance match the evidence?
+2. Is the confidence level appropriate given the number and severity of issues?
+3. Are the remarks accurate and professional?
+
+If the first pass is correct, return it unchanged. If not, return a corrected version.
+
+Return only valid JSON, no markdown:
+{
+  "reasoning": "your review analysis",
+  "remarks": "corrected or unchanged 2-4 sentence professional conformance statement",
+  "confidence": "high | medium | low",
+  "referenced_issues": [{ "title": "...", "severity": "..." }],
+  "suggested_conformance": "supports | does_not_support | not_applicable"
+}`;
+}
+
+/**
  * Parses and validates a raw JSON string returned by the AI for a VPAT row.
  *
  * Validates that the parsed object contains all required fields with the correct types,

--- a/src/lib/ai/types.ts
+++ b/src/lib/ai/types.ts
@@ -29,5 +29,9 @@ export interface AIProvider {
   generateExecutiveSummaryHtml(context: string): Promise<string>;
   generateVpatRemarks(issueSummary: string, criterion: string): Promise<string>;
   generateVpatRow(context: VpatGenerationContext): Promise<VpatRowGenerationResult>;
+  reviewVpatRow(
+    context: VpatGenerationContext,
+    firstPass: VpatRowGenerationResult
+  ): Promise<VpatRowGenerationResult>;
   testConnection(): Promise<{ ok: boolean; error?: string }>;
 }

--- a/src/lib/ai/vercel-provider.ts
+++ b/src/lib/ai/vercel-provider.ts
@@ -15,6 +15,7 @@ import {
   buildExecutiveSummaryUser,
   buildVpatRemarksUser,
   buildVpatRowPrompt,
+  buildVpatReviewPrompt,
   parseVpatRowResponse,
 } from './prompts';
 
@@ -159,6 +160,25 @@ export class VercelAIProvider implements AIProvider {
     const { text } = await generateText({
       model: this.model,
       prompt: buildVpatRowPrompt(context),
+    });
+    return parseVpatRowResponse(text);
+  }
+
+  /**
+   * Critiques and optionally corrects a first-pass VPAT row result.
+   *
+   * @param context - The original criterion metadata and array of mapped issues.
+   * @param firstPass - The result from the first `generateVpatRow` call.
+   * @returns A Promise resolving to a validated `VpatRowGenerationResult`.
+   * @throws {Error} If the AI response is not valid JSON or is missing required fields.
+   */
+  async reviewVpatRow(
+    context: VpatGenerationContext,
+    firstPass: VpatRowGenerationResult
+  ): Promise<VpatRowGenerationResult> {
+    const { text } = await generateText({
+      model: this.model,
+      prompt: buildVpatReviewPrompt(context, firstPass),
     });
     return parseVpatRowResponse(text);
   }

--- a/src/lib/db/settings.ts
+++ b/src/lib/db/settings.ts
@@ -16,8 +16,13 @@ interface SettingRow {
 const DEFAULT_SETTINGS: Record<string, SettingValue> = {
   ai_provider: 'none',
   ai_api_key: '',
-  ai_model: '',
+  ai_model: '', // kept as global fallback for existing installs
   ai_base_url: '',
+  ai_model_issues: '',
+  ai_model_vpat: '',
+  ai_model_reports: '',
+  ai_model_vpat_review: '',
+  ai_review_pass_enabled: false,
   media_directory: './data/media',
   auth_enabled: false,
   app_version: '1.0.0',


### PR DESCRIPTION
## Summary

- Replaces the single global AI model setting with per-task model selectors (Issue Analysis, VPAT Generation, Report Writing, AI Review Pass), each with a dropdown of known models per provider plus an \"Other…\" free-text option
- Adds an optional **AI Review Pass** — a global toggle that sends each VPAT criterion row through a second critique call after generation, using its own model slot, to verify and correct the conformance call if the evidence doesn't support it
- Fixes the Generate button missing from multi-component VPAT criterion rows, and fixes two bugs in the generate-all route (missing \`ai_suggested_conformance\`/\`ai_referenced_issues\` fields and missing \`id\`/\`assessment_id\` in the SQL query)

## What changed

- `src/lib/ai/models.ts` (new) — known model lists per provider + `AI_TASKS` metadata + `TASK_MODEL_SETTINGS` map
- `src/lib/ai/index.ts` — `getAIProvider(task?)` resolves model via: env var → task-specific setting → global `ai_model` fallback → provider default
- `src/lib/ai/types.ts` + `vercel-provider.ts` + `prompts.ts` — `reviewVpatRow` method + `buildVpatReviewPrompt`
- `src/lib/db/settings.ts` — 5 new default keys (`ai_model_issues`, `ai_model_vpat`, `ai_model_reports`, `ai_model_vpat_review`, `ai_review_pass_enabled`)
- All AI route callers updated to pass task arg to `getAIProvider`
- Both VPAT generate routes updated with review pass logic + bug fixes
- `AIConfigSection` redesigned with `TaskModelSelector` sub-component; `settings-client.tsx` + `settings/page.tsx` wired through

## Test Plan

- [x] Settings page shows four task model dropdowns when a cloud provider is selected
- [x] Dropdowns list known models for the selected provider; choosing "Other…" reveals a free text input
- [x] Task model section is hidden when provider is "None"
- [x] AI Review Pass toggle shows/hides the review model slot
- [x] Saving persists all model choices; reloading the page restores them
- [x] VPAT generate (single row) uses the VPAT model slot; review pass fires when enabled
- [x] VPAT generate-all uses the VPAT model slot; review pass fires for each row when enabled
- [x] Multi-component VPAT rows show the Generate button
- [x] All 1880 unit tests pass