### PR TITLE
feat(issues, assessments): add filtering by status in list views

### DIFF
--- a/__tests__/components/assessments/assessments-list-view.test.tsx
+++ b/__tests__/components/assessments/assessments-list-view.test.tsx
@@ -1,7 +1,12 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
 import { NextIntlClientProvider } from 'next-intl';
 import en from '@/messages/en.json';
+
+vi.mock('next/navigation', () => ({
+  useSearchParams: () => ({ get: () => null }),
+}));
 import { AssessmentsListView } from '@/components/assessments/assessments-list-view';
 import type { AssessmentWithProject } from '@/lib/db/assessments';
 

--- a/src/app/(app)/assessments/__tests__/page.test.tsx
+++ b/src/app/(app)/assessments/__tests__/page.test.tsx
@@ -3,6 +3,10 @@ import { vi } from 'vitest';
 import { NextIntlClientProvider } from 'next-intl';
 import en from '@/messages/en.json';
 
+vi.mock('next/navigation', () => ({
+  useSearchParams: () => ({ get: () => null }),
+}));
+
 vi.mock('@/lib/db/assessments', () => ({
   getAllAssessments: () =>
     Promise.resolve([

--- a/src/components/assessments/__tests__/assessments-list-view.test.tsx
+++ b/src/components/assessments/__tests__/assessments-list-view.test.tsx
@@ -4,6 +4,10 @@ import { vi, describe, it, expect } from 'vitest';
 import { NextIntlClientProvider } from 'next-intl';
 import en from '@/messages/en.json';
 
+vi.mock('next/navigation', () => ({
+  useSearchParams: () => ({ get: () => null }),
+}));
+
 vi.mock('@/components/assessments/all-assessments-table', () => ({
   AllAssessmentsTable: () => <div data-testid="assessments-table" />,
 }));

--- a/src/components/assessments/assessments-list-view.tsx
+++ b/src/components/assessments/assessments-list-view.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import Link from 'next/link';
 import { Plus } from 'lucide-react';
+import { useSearchParams } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
@@ -18,6 +19,13 @@ interface AssessmentsListViewProps {
 export function AssessmentsListView({ assessments }: AssessmentsListViewProps) {
   const t = useTranslations('assessments.list');
   const [view, setView] = useState<'grid' | 'table'>('table');
+  const searchParams = useSearchParams();
+  const status = searchParams.get('status') as 'ready' | 'in_progress' | 'completed' | null;
+
+  const filtered =
+    status && (['ready', 'in_progress', 'completed'] as const).includes(status)
+      ? assessments.filter((a) => a.status === status)
+      : assessments;
 
   return (
     <div className="p-6 space-y-6">
@@ -38,7 +46,7 @@ export function AssessmentsListView({ assessments }: AssessmentsListViewProps) {
         </div>
       </section>
 
-      {assessments.length === 0 ? (
+      {filtered.length === 0 ? (
         <div className="rounded-lg border border-dashed p-12 text-center">
           <p className="text-muted-foreground">{t('empty_heading')}</p>
           <Button asChild variant="outline" className="mt-4">
@@ -47,14 +55,14 @@ export function AssessmentsListView({ assessments }: AssessmentsListViewProps) {
         </div>
       ) : view === 'grid' ? (
         <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
-          {assessments.map((a) => (
+          {filtered.map((a) => (
             <AssessmentCard key={a.id} assessment={a} />
           ))}
         </div>
       ) : (
         <Card>
           <CardContent>
-            <AllAssessmentsTable assessments={assessments} />
+            <AllAssessmentsTable assessments={filtered} />
           </CardContent>
         </Card>
       )}

--- a/src/components/issues/issues-list-view.tsx
+++ b/src/components/issues/issues-list-view.tsx
@@ -28,9 +28,16 @@ export function IssuesListView({ issues }: IssuesListViewProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
   const severity = searchParams.get('severity');
+  const status = searchParams.get('status') as 'open' | 'resolved' | 'wont_fix' | null;
 
   function handleSeverityChange(value: string) {
-    router.push(value ? `/issues?severity=${value}` : '/issues');
+    const params = new URLSearchParams(searchParams.toString());
+    if (value) {
+      params.set('severity', value);
+    } else {
+      params.delete('severity');
+    }
+    router.push(params.size > 0 ? `/issues?${params.toString()}` : '/issues');
   }
 
   const afterSeverity =
@@ -38,8 +45,13 @@ export function IssuesListView({ issues }: IssuesListViewProps) {
       ? issues.filter((i) => i.severity === severity)
       : issues;
 
+  const afterStatus =
+    status && (['open', 'resolved', 'wont_fix'] as const).includes(status)
+      ? afterSeverity.filter((i) => i.status === status)
+      : afterSeverity;
+
   const filtered = query.trim()
-    ? afterSeverity.filter((i) => {
+    ? afterStatus.filter((i) => {
         const q = query.toLowerCase();
         return (
           i.title.toLowerCase().includes(q) ||
@@ -48,7 +60,7 @@ export function IssuesListView({ issues }: IssuesListViewProps) {
           i.project_name.toLowerCase().includes(q)
         );
       })
-    : afterSeverity;
+    : afterStatus;
 
   return (
     <section aria-labelledby="issues-heading" className="p-6 space-y-6">


### PR DESCRIPTION
## Summary

- `IssuesListView` now reads the `status` query param and filters the list — clicking "Open Critical Issues" or "Resolved This Month" on the dashboard now works
- `AssessmentsListView` now reads the `status` query param and filters the list — clicking "In-Progress Assessments" on the dashboard now works
- Fixed `handleSeverityChange` in `IssuesListView` to preserve existing query params (e.g. `status`) when switching severity tabs

## Test plan

- [x] Click "Open Critical Issues" stat card on the dashboard → issues page shows only open + critical issues
- [x] Click "Resolved This Month" stat card → issues page shows only resolved issues
- [x] Click "In-Progress Assessments" stat card → assessments page shows only in-progress assessments
- [x] Verify that changing the severity tab on the issues page preserves any active status filter in the URL
- [x] Verify that navigating to `/issues` or `/assessments` with no params still shows all records